### PR TITLE
include postcss and autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "redux": "3.0.5"
   },
   "devDependencies": {
+    "autoprefixer": "6.3.1",
     "babel": "5.8.23",
     "babel-eslint": "4.1.7",
     "babel-loader": "5.1.4",
@@ -45,6 +46,7 @@
     "mocha": "2.3.4",
     "node-sass": "3.4.2",
     "parallelshell": "2.0.0",
+    "postcss-loader": "0.8.0",
     "react-transform-catch-errors": "1.0.1",
     "react-transform-hmr": "1.0.1",
     "redbox-react": "1.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@
 import webpack from 'webpack';
 import path from 'path';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
+import autoprefixer from 'autoprefixer';
 
 const developmentEnvironment = 'development' ;
 const productionEnvironment = 'production';
@@ -56,13 +57,13 @@ const getLoaders = function (env) {
     loaders.push({
       test: /(\.css|\.scss)$/,
       include: path.join(__dirname, 'src'),
-      loader: ExtractTextPlugin.extract("css?sourceMap!sass?sourceMap")
+      loader: ExtractTextPlugin.extract("css?sourceMap!postcss!sass?sourceMap")
     });
   } else {
     loaders.push({
       test: /(\.css|\.scss)$/,
       include: path.join(__dirname, 'src'),
-      loaders: ['style', 'css?sourceMap', 'sass?sourceMap']
+      loaders: ['style', 'css?sourceMap', 'postcss', 'sass?sourceMap']
     });
   }
 
@@ -84,7 +85,8 @@ function getConfig(env) {
     plugins: getPlugins(env),
     module: {
       loaders: getLoaders(env)
-    }
+    },
+    postcss: ()=> [autoprefixer]
   };
 }
 


### PR DESCRIPTION
Include autoprefixer into the css tool chain. Autoprefixer recommends it's application via the postcss library, thus the inclusion of the postcss-loader.