### PR TITLE
connect-history-api-fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chai": "3.4.1",
     "cheerio": "0.19.0",
     "colors": "1.1.2",
+    "connect-history-api-fallback": "1.1.0",
     "cross-env": "1.0.7",
     "css-loader": "0.23.1",
     "eslint": "1.10.3",

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="bundle.js"></script>
+    <script src="/bundle.js"></script>
   </body>
 </html>

--- a/tools/buildHtml.js
+++ b/tools/buildHtml.js
@@ -21,8 +21,9 @@ fs.readFile('src/index.html', 'utf8', (err, markup) => {
 
   const $ = cheerio.load(markup);
 
-  // since a separate spreadsheet is only utilized for the production build, need to dynamically add this here.
-  $('head').prepend('<link rel="stylesheet" href="styles.css">');
+  // since a separate stylesheet is only utilized for the production build, need to dynamically add this here.
+  // if using connect-history-fallback-api need to prefix with / so that is is served from the root.
+  $('head').prepend('<link rel="stylesheet" href="/styles.css">');
 
   if (useTrackJs) {
     if (trackJsToken) {
@@ -42,4 +43,3 @@ fs.readFile('src/index.html', 'utf8', (err, markup) => {
 
   console.log('index.html written to /dist'.green);
 });
-

--- a/tools/distServer.js
+++ b/tools/distServer.js
@@ -2,6 +2,7 @@
 // on your local machine.
 
 import browserSync from 'browser-sync';
+import historyApiFallback from 'connect-history-api-fallback';
 
 // Run Browsersync
 browserSync({
@@ -15,5 +16,6 @@ browserSync({
 
   files: [
     'src/*.html'
-  ]
+  ],
+  middleware: [historyApiFallback()]
 });

--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -3,6 +3,7 @@
 
 // Require Browsersync along with webpack and middleware for it
 import browserSync from 'browser-sync';
+import historyApiFallback from 'connect-history-api-fallback';
 import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
@@ -32,7 +33,11 @@ browserSync({
       }),
 
       // bundler should be the same as above
-      webpackHotMiddleware(bundler)
+      webpackHotMiddleware(bundler),
+
+      //allow for the use of a router in the react application
+      //so that any url will resolve to index.html
+      historyApiFallback()
     ]
   },
 


### PR DESCRIPTION
Adds connect-history-api-fallback to the project, which will allow SPAs
to always return the index.html file for any url entry.