### PR TITLE
webpack-hot-middleware/client reload params configured to true

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ const getEntry = function (env) {
   const entry = [];
 
   if (env === developmentEnvironment ) { // only want hot reloading when in dev.
-    entry.push('webpack-hot-middleware/client');
+    entry.push('webpack-hot-middleware/client?reload=true');
   }
 
   entry.push('./src/index');


### PR DESCRIPTION
I think it will be better DX to have full reload when webpack gets stuck.[config](https://github.com/glenjamin/webpack-hot-middleware#config)
This very useful for case when HMR fails due to [stateless functional components](https://github.com/gaearon/babel-plugin-react-transform/issues/57#issuecomment-167675819). It's easy to reproduce for top level components like `App` or `AboutPage`