### PR TITLE
adding react-css-modules support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "connect-history-api-fallback": "1.1.0",
     "object-assign": "4.0.1",
     "react": "0.14.7",
+    "react-css-modules": "3.7.6",
     "react-dom": "0.14.7",
     "react-redux": "4.4.0",
     "react-router": "2.0.0",

--- a/src/components/FuelSavingsResults.js
+++ b/src/components/FuelSavingsResults.js
@@ -1,6 +1,9 @@
 import React, {PropTypes} from 'react';
 import NumberFormatter from '../businessLogic/numberFormatter';
 
+import CSSModules from 'react-css-modules';
+import styles from './FuelSavingsResults.scss';
+
 //This is a stateless functional component. (Also known as pure or dumb component)
 //More info: https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components
 //And https://medium.com/@joshblack/stateless-components-in-react-0-14-f9798f8b992d
@@ -17,7 +20,7 @@ const FuelSavingsResults = ({savings}) => {
       <table>
         <tbody>
         <tr>
-          <td className="fuel-savings-label">{resultLabel}</td>
+          <td styleName="fuel-savings-label">{resultLabel}</td>
           <td>
             <table>
               <tbody>
@@ -27,9 +30,9 @@ const FuelSavingsResults = ({savings}) => {
                 <td>3 Year</td>
               </tr>
               <tr>
-                <td className={savingsClass}>{savings.monthly}</td>
-                <td className={savingsClass}>{savings.annual}</td>
-                <td className={savingsClass}>{savings.threeYear}</td>
+                <td styleName={savingsClass}>{savings.monthly}</td>
+                <td styleName={savingsClass}>{savings.annual}</td>
+                <td styleName={savingsClass}>{savings.threeYear}</td>
               </tr>
               </tbody>
             </table>
@@ -46,4 +49,4 @@ FuelSavingsResults.propTypes = {
     savings: PropTypes.object.isRequired
 };
 
-export default FuelSavingsResults;
+export default CSSModules(FuelSavingsResults, styles);

--- a/src/components/FuelSavingsResults.scss
+++ b/src/components/FuelSavingsResults.scss
@@ -1,0 +1,6 @@
+$vin-green: #60b044;
+$vin-red: #ff0000;
+
+.savings { color: $vin-green; }
+.loss { color: $vin-red; }
+.fuel-savings-label { width: 175px; }

--- a/src/components/FuelSavingsTextInput.css
+++ b/src/components/FuelSavingsTextInput.css
@@ -1,0 +1,3 @@
+.small {
+  width: 46px;
+}

--- a/src/components/FuelSavingsTextInput.js
+++ b/src/components/FuelSavingsTextInput.js
@@ -1,12 +1,15 @@
 import React, { Component, PropTypes } from 'react';
 
+import CSSModules from 'react-css-modules';
+import styles from './FuelSavingsTextInput.css';
+
 const FuelSavingsTextInput = (props) => {
   const handleChange = (e) => {
     props.onChange(props.name, e.target.value);
   };
 
   return (
-    <input className="small"
+    <input styleName="small"
       type="text"
       placeholder={props.placeholder}
       value={props.value}
@@ -24,4 +27,4 @@ FuelSavingsTextInput.propTypes = {
 	])
 };
 
-export default FuelSavingsTextInput;
+export default CSSModules(FuelSavingsTextInput, styles);

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,7 +1,5 @@
 /* Variables */
 $vin-blue: #5bb7db;
-$vin-green: #60b044;
-$vin-red: #ff0000;
 
 /* Styles */
 body {
@@ -24,8 +22,3 @@ td {
 h2 {
 	color: $vin-blue;
 }
-
-.savings { color: $vin-green; }
-.loss { color: $vin-red; }
-input.small { width: 46px; }
-td.fuel-savings-label { width: 175px; }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,9 +54,19 @@ const getLoaders = function (env) {
 
   if (env === productionEnvironment ) {
     // generate separate physical stylesheet for production build using ExtractTextPlugin. This provides separate caching and avoids a flash of unstyled content on load.
-    loaders.push({test: /(\.css|\.scss)$/, loader: ExtractTextPlugin.extract("css?sourceMap!sass?sourceMap")});
+    loaders.push({
+      test: /(\.css|\.scss)$/,
+      loader: ExtractTextPlugin.extract('css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!sass?sourceMap')
+    });
   } else {
-    loaders.push({test: /(\.css|\.scss)$/, loaders: ['style', 'css?sourceMap', 'sass?sourceMap']});
+    loaders.push({
+      test: /(\.css|\.scss)$/,
+      loaders: [
+        'style',
+        'css?sourceMap&modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
+        'sass?sourceMap'
+      ]
+    });
   }
 
   return loaders;


### PR DESCRIPTION
Adds enhancement from https://github.com/coryhouse/react-slingshot/issues/71.

But tests are failing. Babel is trying to parse the .scss and .css files in src.
I think that babel was always parsing all the files in src folder and not just *.spec.js files.