### PR TITLE
Fix compose error in configure store dev version

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -2,7 +2,7 @@
 //This boilerplate file is likely to be the same for each project that uses Redux.
 //With Redux, the actual stores are in /reducers.
 
-import { createStore } from 'redux';
+import { createStore, compose } from 'redux';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {


### PR DESCRIPTION
fix error  'compose' is not defined in configureStore.dev.js