### PR TITLE
Now there is a pre-check to see if there are any tests to run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prebuild": "npm run clean-dist",
     "build": "npm-run-all --parallel test build:html build:js",
     "postbuild": "npm run open:dist",
+    "pretest": "babel-node tools/runTestsPreFlight.js --glob \"./src/**/*.spec.js\"",
     "test": "cross-env NODE_ENV=test mocha --reporter progress --compilers js:babel-core/register --recursive \"./src/**/*.spec.js\" --require ignore-styles",
     "test:watch": "npm run test -- --watch"
   },
@@ -50,6 +51,7 @@
     "eslint-plugin-react": "4.0.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
+    "glob": "7.0.3",
     "ignore-styles": "1.2.0",
     "mocha": "2.3.4",
     "node-sass": "3.4.2",

--- a/tools/runTestsPreFlight.js
+++ b/tools/runTestsPreFlight.js
@@ -1,0 +1,15 @@
+import glob from 'glob';
+import yargs from 'yargs';
+
+const args = yargs.argv;
+const globPattern = args.glob;
+
+glob(globPattern, {}, (err, files) => {
+  if (files.length === 0) {
+    const noTestsMessage = `No tests found matching the glob ${globPattern}. \
+Create at least one test or disable tests (not recommended).`;
+
+    console.warn(noTestsMessage); // eslint-disable-line no-console
+    process.exit(1); // Returning 1 instead of the normal 0 so that the npm "test" script does not run.
+  }
+});


### PR DESCRIPTION
@coryhouse, this fixes #40 . The only thing I don't like is that I have to specify the glob in the `pretest` and `test` scripts. I can set the process.env.testsGlob to the pattern passed in from the runTestsPreFlight.js script, but when the `test` script runs, I do not know how to pass it to mocha. Open to suggestions or we can go as is.