### PR TITLE
Added redux logger middleware

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -59,6 +59,7 @@ Unfortunately, scripts in package.json can't be commented inline because the JSO
 |react-redux|Redux library for connecting React components to Redux |
 |react-router|React library for routing |
 |redux|Library for unidirectional data flows |
+|redux-logger|Logs Redux actions and states to console |
 |babel-cli|Babel Command line interface |
 |babel-core|Babel Core for transpiling the new JavaScript to old |
 |babel-eslint|Connects Babel and ESLint so ES6 code can be linted |

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "object-assign": "4.0.1",
     "react": "15.0.1",
     "react-dom": "15.0.1",
-    "react-redux": "4.4.0",
+    "react-redux": "4.4.5",
     "react-router": "2.0.0",
     "redux": "3.4.0"
   },
@@ -55,6 +55,7 @@
     "node-sass": "3.4.2",
     "npm-run-all": "1.7.0",
     "react-addons-test-utils": "15.0.1",
+    "redux-logger": "2.6.1",
     "rimraf": "2.5.2",
     "sass-loader": "3.2.0",
     "sinon": "1.17.3",

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -2,12 +2,15 @@
 //This boilerplate file is likely to be the same for each project that uses Redux.
 //With Redux, the actual stores are in /reducers.
 
-import { createStore, compose } from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
 import rootReducer from '../reducers';
+import createLogger from 'redux-logger';
 
 export default function configureStore(initialState) {
+  const logger = createLogger();
   let store = createStore(rootReducer, initialState, compose(
     // Add other middleware on this line...
+    applyMiddleware(logger),
     window.devToolsExtension ? window.devToolsExtension() : f => f //add support for Redux dev tools
     )
   );

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -10,7 +10,7 @@ export default function configureStore(initialState) {
   const logger = createLogger();
   let store = createStore(rootReducer, initialState, compose(
     // Add other middleware on this line...
-    applyMiddleware(logger),
+    applyMiddleware(logger), // logger needs to be the last item in applyMiddleware to prevent unnecessary logging of other middlewares
     window.devToolsExtension ? window.devToolsExtension() : f => f //add support for Redux dev tools
     )
   );


### PR DESCRIPTION
I prefer to use this way to monitor my state and I think it would be good candidate for the starter kit since it shows how the action modified the state object.

Allows people to see Redux without getting Redux Dev tools installed.
Demonstrates exactly how to add middleware within compose so should be easier for people to add something like thunk.

Bumped the react-redux version to avoid an npm dependency warning for react 0.14