### PR TITLE
Add babel-register as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-react": "6.5.0",
     "babel-preset-react-hmre": "1.1.1",
     "babel-preset-stage-1": "6.5.0",
+    "babel-register": "6.7.2",
     "browser-sync": "2.11.2",
     "chai": "3.5.0",
     "cheerio": "0.20.0",


### PR DESCRIPTION
Babel register module was added to [testSetup](https://github.com/coryhouse/react-slingshot/commit/16ec28c9029bf7e2b65b26c22a1c2daadab427a2#diff-6c723dbdc461fd954bf1d26883b049c7R26) but it wasn't added as an explicit dependency. On clean environment `npm test` fails with `Error: Cannot find module 'babel-register'`

The issue was also reported here https://github.com/coryhouse/react-slingshot/issues/116 .