### PR TITLE
Copy favicon.ico asset to the /dist directory during build

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>React Slingshot</title>
+    <link rel="shortcut icon" href="favicon.ico">
   </head>
   <body>
     <div id="app"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import routes from './routes';
 import configureStore from './store/configureStore';
+require('./favicon.ico'); //Tell webpack to load favicon.ico
 import './styles/styles.scss'; //Yep, that's right. You can import SASS/CSS files too! Webpack will run the associated loader and plug this into the page.
 
 const store = configureStore();

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -29,6 +29,7 @@ export default {
     loaders: [
       {test: /\.js$/, include: path.join(__dirname, 'src'), loaders: ['babel']},
       {test: /\.(jpe?g|png|gif|svg)$/i, loaders: ['file']},
+      {test: /\.ico$/, loader: 'file-loader?name=[name].[ext]'},
       {test: /(\.css|\.scss)$/, loaders: ['style', 'css?sourceMap', 'sass?sourceMap']}
     ]
   }

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -29,6 +29,7 @@ export default {
     loaders: [
       {test: /\.js$/, include: path.join(__dirname, 'src'), loaders: ['babel']},
       {test: /\.(jpe?g|png|gif|svg)$/i, loaders: ['file']},
+      {test: /\.ico$/, loader: 'file-loader?name=[name].[ext]'},
       {
         test: /(\.css|\.scss)$/,
         include: path.join(__dirname, 'src'),


### PR DESCRIPTION
Resolves the issue of not being able to "copy" a `favicon.ico` to the `/dist` directory during `npm run build`, see https://github.com/coryhouse/react-slingshot/issues/128. 