### PR TITLE
Don't use no-unused-vars:0 and jsx-uses-vars:1 together

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
     "semi": [1, "always"],
     "no-trailing-spaces": 0,
     "eol-last": 0,
-    "no-unused-vars": 0,
     "no-underscore-dangle": 0,
     "no-alert": 0,
     "no-lone-blocks": 0,


### PR DESCRIPTION
We don't need to enable "jsx-uses-vars" when "no-unused-vars" is disabled. Linting for unused vars is useful so I've left no-unused-vars enabled from "eslint:recommended", however disabling "no-unused-vars" and removing "jsx-uses-vars" would be equally valid.

"If you are not using JSX or if you do not use the no-unused-vars rule then you can disable this rule." ref: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md#when-not-to-use-it