### PR TITLE
Added .scss as excluded feature for tests

### DIFF
--- a/tools/testSetup.js
+++ b/tools/testSetup.js
@@ -11,15 +11,9 @@ process.env.NODE_ENV = 'production';
 
 // Disable webpack-specific features for tests since
 // Mocha doesn't know what to do with them.
-require.extensions['.css'] = () => {
-  return null;
-};
-require.extensions['.png'] = () => {
-  return null;
-};
-require.extensions['.jpg'] = () => {
-  return null;
-};
+['.css', '.scss', '.png', '.jpg'].forEach(ext => {
+  require.extensions[ext] = () => null;
+});
 
 // Register babel so that it will transpile ES6 to ES5
 // before our tests run.


### PR DESCRIPTION
While `.scss` is currently nowhere used in files that are imported from tests, it is possible that someone might `import` sass files directly from components which then will fail for tests.

I thought about adding `.ico` but since this will only ever be used in `index.js` I don't see why anyone would have tests there. I'm happy to add it if anyone thinks it's necessary, though.