### PR TITLE
Fixed some spec files being ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:html": "babel-node tools/buildHtml.js",
     "prebuild": "npm run clean-dist && npm run build:html && npm run lint && npm run test",
     "build": "babel-node tools/build.js && npm run open:dist",
-    "test": "mocha tools/testSetup.js src/**/*.spec.js --reporter progress",
+    "test": "mocha tools/testSetup.js \"src/**/*.spec.js\" --reporter progress",
     "test:watch": "npm run test -- --watch"
   },
   "author": "Cory House",


### PR DESCRIPTION
At a certain point in my project, `npm test` started to ignore certain spec files. I don't know enough about npm as to know why this happened but I guess it has to do with how the `package.json` file is read and how the command is executed (shell, env, user, …).

A fresh `react-slingshot` checkout works fine.

I fixed it for my project by passing the `src/**/*.spec.js` argument wrapped in double-quotes (see diff).

For reference, my only spec files:

```
./src/components/Mui/Row.spec.js
./src/components/Mui/Icon.spec.js
./src/components/Mui/Form/TextInput.spec.js
./src/components/Mui/Form/FormField.spec.js
./src/components/ContinueButtons.spec.js
```

If I execute `mocha tools/testSetup.js src/**/*.spec.js` in zsh it works and runs all spec files. If I do `npm test` (without this PR applied) it only runs `ContinueButtons.spec.js`. With this PR it runs them all.