### PR TITLE
Added Support for ES6 Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ node_js:
   - "4.1"
   - "4.0"
 after_success:
-  # Uncomment the line below if you have setup Coveralls as described in the FAQ.
+  # Send coverage data to coveralls.
   - npm run test:cover:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ node_js:
   - "4.2"
   - "4.1"
   - "4.0"
+after_success:
+  # Uncomment the line below if you have setup Coveralls as described in the FAQ.
+  - npm run test:cover:travis

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![build status](https://img.shields.io/travis/coryhouse/react-slingshot.svg?style=flat-square)](https://travis-ci.org/coryhouse/react-slingshot)
 [![Dependency Status](https://david-dm.org/coryhouse/react-slingshot.svg?style=flat-square)](https://david-dm.org/coryhouse/react-slingshot)
+[![Coverage Status](https://coveralls.io/repos/github/dwmkerr/react-slingshot/badge.svg?branch=master)](https://coveralls.io/github/dwmkerr/react-slingshot?branch=master)
 
 React Slingshot is a comprehensive starter kit for rapid application development using React. It offers a rich development experience including:
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ React Slingshot is a comprehensive starter kit for rapid application development
 | [Webpack](http://webpack.github.io) | Bundles npm packages and our JS into a single file. Includes hot reloading via [react-transform-hmr](https://www.npmjs.com/package/react-transform-hmr). | [Quick Webpack How-to](https://github.com/petehunt/webpack-howto) [Pluralsight Course](https://www.pluralsight.com/courses/webpack-fundamentals)|
 | [Browsersync](https://www.browsersync.io/) | Lightweight development HTTP server that supports synchronized testing and debugging on multiple devices. | [Intro vid](https://www.youtube.com/watch?time_continue=1&v=heNWfzc7ufQ)|
 | [Mocha](http://mochajs.org) | Automated tests with [Chai](http://chaijs.com/) for assertions and [Enzyme](https://github.com/airbnb/enzyme) for DOM testing without a browser using Node. | [Pluralsight Course](https://www.pluralsight.com/courses/testing-javascript) |
+| [Isparta](https://github.com/douglasduteil/isparta) | Code coverage tool for ES6 code transpiled by Babel. | 
 | [TrackJS](https://trackjs.com/) | JavaScript error tracking. | [Free trial](https://my.trackjs.com/signup)|  
 | [ESLint](http://eslint.org/)| Lint JS. Reports syntax and style issues. Using [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) for additional React specific linting rules. | |
 | [SASS](http://sass-lang.com/) | Compiled CSS styles with variables, functions, and more. | [Pluralsight Course](https://www.pluralsight.com/courses/better-css)|

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -175,6 +175,16 @@ In short, Gulp is an unnecessary abstraction that creates more problems than it 
 ### Why does package.json reference the exact version?
 This assures that the build won't break when some new version is released. Unfortunately, many package authors don't properly honor [Semantic Versioning](http://semver.org), so instead, as new versions are released, I'll test them and then introduce them into the starter kit. But yes, this means when you do `npm update` no new dependencies will be pulled down. You'll have to update package.json with the new version manually.
 
+### How do I handle images?
+Via <a href="https://github.com/webpack/file-loader">Webpack's file loader</a>. Example: 
+
+```
+<img src={require('./src/images/myImage.jpg')} />
+
+```
+
+Webpack will then intelligently handle your image for you. For the production build, it will copy the physical file to /dist, give it a unique filename, and insert the appropriate path in your image tag.
+
 ### I'm getting an error when running npm install: Failed to locate "CL.exe"
 On Windows, you need to install extra dependencies for browser-sync to build and install successfully. Follow the getting started steps above to assure you have the necessary dependencies on your machine.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -204,3 +204,13 @@ Using the `npm run test:cover` command to run the tests, building a code coverag
 npm run test:cover
 open ./coverage/index.html
 ```
+
+You can add code coverage metrics to your `README.md` file and pull by integrating with [Coveralls](https://coveralls.io/).
+
+1. Sign in to Coveralls with your GitHub account.
+2. Authorise Coveralls to access your repositories.
+3. Choose 'Add Repo' and select your repo.
+4. Uncomment the 'Send Coverage Data to Coveralls from Travis' line in [.travis.yml].
+
+That's it! Travis will now execute the `npm run test:cover:travis` script after a successful build, which will write the coverage report in the standard lcov format and send it directly to Coveralls. The environment variables provided for travis jobs are used to automatically target the correct Coveralls project, as long as it is set up as described above.
+

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -196,3 +196,11 @@ Install the [Redux devtools extension](https://chrome.google.com/webstore/detail
 
 ### Hot reloading isn't working!
 Hot reloading doesn't always play nicely with stateless functional components at this time. [This is a known limitation that is currently being worked](https://github.com/gaearon/babel-plugin-react-transform/issues/57). To avoid issues with hot reloading for now, use a traditional class-based React component at the top of your component hierarchy.
+
+### How do I setup code coverage reporting?
+Using the `npm run test:cover` command to run the tests, building a code coverage report. The report is writtent to `coverage/index.html`. A quick way to check coverage is:
+
+```bash
+npm run test:cover
+open ./coverage/index.html
+```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -212,7 +212,8 @@ You can add code coverage metrics to your `README.md` file and pull by integrati
 1. Sign in to Coveralls with your GitHub account.
 2. Authorise Coveralls to access your repositories.
 3. Choose 'Add Repo' and select your repo.
-4. Uncomment the 'Send Coverage Data to Coveralls from Travis' line in [.travis.yml].
 
 That's it! Travis will now execute the `npm run test:cover:travis` script after a successful build, which will write the coverage report in the standard lcov format and send it directly to Coveralls. The environment variables provided for travis jobs are used to automatically target the correct Coveralls project, as long as it is set up as described above.
+
+You can get the badge from the Coveralls website.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prebuild": "npm run clean-dist && npm run build:html && npm run lint && npm run test",
     "build": "babel-node tools/build.js && npm run open:dist",
     "test": "mocha tools/testSetup.js src/**/*.spec.js --reporter progress",
+    "test:cover": "babel-node $(npm bin)/isparta cover --root src --report html node_modules/mocha/bin/_mocha -- --require ./tools/testSetup.js src/**/*.spec.js --reporter progress",
     "test:watch": "npm run test -- --watch"
   },
   "author": "Cory House",
@@ -55,6 +56,7 @@
     "eslint-watch": "2.1.11",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
+    "isparta": "4.0.0",
     "mocha": "2.4.5",
     "node-sass": "3.7.0",
     "npm-run-all": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "babel-node tools/build.js && npm run open:dist",
     "test": "mocha tools/testSetup.js src/**/*.spec.js --reporter progress",
     "test:cover": "babel-node $(npm bin)/isparta cover --root src --report html node_modules/mocha/bin/_mocha -- --require ./tools/testSetup.js src/**/*.spec.js --reporter progress",
+    "test:cover:travis": "babel-node ./node_modules/.bin/isparta cover --root src --report lcovonly node_modules/mocha/bin/_mocha -- --require ./tools/testSetup.js src/**/*.spec.js && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:watch": "npm run test -- --watch"
   },
   "author": "Cory House",
@@ -45,6 +46,7 @@
     "chalk": "1.1.3",
     "cheerio": "0.20.0",
     "connect-history-api-fallback": "1.2.0",
+    "coveralls": "2.11.9",
     "cross-env": "1.0.7",
     "css-loader": "0.23.1",
     "enzyme": "2.2.0",


### PR DESCRIPTION
Hi Guys,

Here's a PR which adds coverage support.

### Badge Support

Coverage badge added to the README.md. If the PR is accepted, the coveralls project should be changed to one Cory sets up (instructions for this are in the FAQ).

![image](https://cloud.githubusercontent.com/assets/1926984/15308474/7c0ee7ce-1c10-11e6-918d-09c57e52057b.png)

### Optional integration with Coveralls

Support for the free-for-open-source coveralls tool, just check the FAQ.

![image](https://cloud.githubusercontent.com/assets/1926984/15308497/b15bc938-1c10-11e6-850c-b4c356cc5a07.png)

### Coverage commands

Just run `npm run test:cover` to generate a local HTML coverage report, open it up with `open ./coverage/index.html`.

Would love to know your thoughts. Fixes #108. Fixes #97.

### Questions

Should we keep the coveralls support on by default, or have the users opt-in?