### PR TITLE
Absolute styles.css path for multi-level paths

### DIFF
--- a/tools/buildHtml.js
+++ b/tools/buildHtml.js
@@ -22,7 +22,7 @@ fs.readFile('src/index.html', 'utf8', (readError, markup) => {
   const $ = cheerio.load(markup);
 
   // since a separate spreadsheet is only utilized for the production build, need to dynamically add this here.
-  $('head').prepend('<link rel="stylesheet" href="styles.css">');
+  $('head').prepend('<link rel="stylesheet" href="/styles.css">');
 
   if (useTrackJs) {
     if (trackJsToken) {


### PR DESCRIPTION
Same as `/bundle.js` to support entry points for clients at example.com/en/something. Otherwise you get 404s on production.

Also see #79 