### PR TITLE
Load styles last for same beahviour as in dev mode

### DIFF
--- a/tools/buildHtml.js
+++ b/tools/buildHtml.js
@@ -22,7 +22,7 @@ fs.readFile('src/index.html', 'utf8', (readError, markup) => {
   const $ = cheerio.load(markup);
 
   // since a separate spreadsheet is only utilized for the production build, need to dynamically add this here.
-  $('head').prepend('<link rel="stylesheet" href="/styles.css">');
+  $('head').append('<link rel="stylesheet" href="/styles.css">');
 
   if (useTrackJs) {
     if (trackJsToken) {


### PR DESCRIPTION
In dev mode, local styles are loaded *after* other CSS included in `<head>`. For prod, the `prepend()` makes `styles.css` be parsed *before* the other CSS in`<head>`.

One fix is to use `append()` instead to make sure local styles are loaded last and in the same order as in development.