### PR TITLE
No need for eslint disabling in configureStore

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,4 +1,3 @@
-/* eslint-disable global-require */
 if (process.env.NODE_ENV === 'production') {
   module.exports = require('./configureStore.prod');
 } else {


### PR DESCRIPTION
## Why
Because the linter still pass without this