### PR TITLE
Updated setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.10.0"
   },
-  "keywords:": [
+  "keywords": [
     "react",
     "reactjs",
     "react-router",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "description": "Starter kit for creating apps with React and Redux",
   "scripts": {
-    "setup": "babel-node tools/setup/setupMessage.js && npm install && babel-node tools/setup/setup.js",
+    "setup": "node tools/setup/setupMessage.js && npm install && node tools/setup/setup.js",
     "remove-demo": "babel-node tools/removeDemo.js",
     "start-message": "babel-node tools/startMessage.js",
     "prestart": "npm-run-all --parallel start-message remove-dist",

--- a/tools/setup/setup.js
+++ b/tools/setup/setup.js
@@ -59,6 +59,15 @@ prompt.get(prompts, function(err, result) {
     });
   });
 
+  // reset package.json 'keywords' field to empty state
+  replace({
+    regex: /"keywords": \[[\s\S]+\]/,
+    replacement: `"keywords": []`,
+    paths: ['package.json'],
+    recursive: false,
+    silent: true
+  });
+
   // remove all setup scripts from the 'tools' folder
   console.log(chalkSuccess('\nSetup complete! Cleaning up...\n'));
   rimraf('./tools/setup', error => {

--- a/tools/setup/setup.js
+++ b/tools/setup/setup.js
@@ -1,8 +1,11 @@
-import rimraf from 'rimraf';
-import {chalkSuccess, chalkProcessing} from '../chalkConfig';
-import replace from 'replace';
-import prompt from 'prompt';
-import prompts from './setupPrompts';
+var rimraf = require('rimraf');
+var chalk = require('chalk');
+var replace = require("replace");
+var prompt = require("prompt");
+var prompts = require('./setupPrompts');
+
+var chalkSuccess = chalk.green;
+var chalkProcessing = chalk.blue;
 
 /* eslint-disable no-console */
 

--- a/tools/setup/setupMessage.js
+++ b/tools/setup/setupMessage.js
@@ -1,7 +1,6 @@
 // This script displays an intro message for the setup script
 /* eslint-disable no-console */
-import {chalkProcessing} from '../chalkConfig';
-console.log(chalkProcessing('==========================='));
+console.log('===========================');
 console.log('=  React Slingshot Setup  =');
-console.log(chalkProcessing('===========================\n'));
-console.log(chalkProcessing('Installing dependencies. Please wait...'));
+console.log('===========================\n');
+console.log('Installing dependencies. Please wait...');

--- a/tools/setup/setupPrompts.js
+++ b/tools/setup/setupPrompts.js
@@ -2,7 +2,10 @@
 module.exports = [
   {
     name: 'projectName',
-    description: 'Project name (deafult: new-project)'
+    description: 'Project name (deafult: new-project)',
+    pattern: /^[^._][a-z0-9\.\-_~]+$/,
+    message: 'Limited to: lowercase letters, numbers, period, hyphen, ' +
+    'underscore, and tilde; cannot begin with period or underscore.'
   },
   {
     name: 'version',

--- a/tools/setup/setupPrompts.js
+++ b/tools/setup/setupPrompts.js
@@ -1,8 +1,8 @@
 // Define prompts for use with npm 'prompt' module in setup script
-export default [
+module.exports = [
   {
     name: 'projectName',
-    description: 'Project name (default: new-project)'
+    description: 'Project name (deafult: new-project)'
   },
   {
     name: 'version',


### PR DESCRIPTION
Updated setup tools with the following changes:

- Reverted back to the ES5-ish syntax, since we don't have the babel packages installed yet when the script is launched (I stayed as faithful as possible to the updates you made to my original version)
- Replace the existing 'keywords' array with an empty one
- Validate the name of the package according to npm requirements.

Regarding the validation, I referenced the two links below to try to get the right regex--everything seems solid in my testing, but I am happy to re-visit if you spot any holes. (Basically: URL-friendly, and cannot start with a period or underscore.)

https://github.com/npm/npm/blob/master/doc/files/package.json.md#name
https://stackoverflow.com/questions/695438/safe-characters-for-friendly-url

Let me know if you have any questions or issues.

Thanks,
Gabe