### PR TITLE
Remove typo from comment

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -21,7 +21,7 @@ export default {
     filename: 'bundle.js'
   },
   plugins: [
-    new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.htmlnew webpack.HotModuleReplacementPlugin());
+    new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.html
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],


### PR DESCRIPTION
Just removed the 'new webpack.HotModuleReplacementPlugin());' from the comment block