### PR TITLE
Fix nested route refresh in dev mode, closes #65

### DIFF
--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -23,6 +23,8 @@ browserSync({
     baseDir: 'src',
 
     middleware: [
+      historyApiFallback(),
+
       webpackDevMiddleware(bundler, {
         // Dev middleware can't access config, so we provide publicPath
         publicPath: config.output.publicPath,
@@ -38,9 +40,7 @@ browserSync({
       }),
 
       // bundler should be the same as above
-      webpackHotMiddleware(bundler),
-
-      historyApiFallback()
+      webpackHotMiddleware(bundler)
     ]
   },
 


### PR DESCRIPTION
Moved `historyApiFallback()` out of `webpackDevMiddleware()` config and into browsersync middleware array. Fixes refresh as well as auto reload issue on nested routes.

Closes https://github.com/coryhouse/react-slingshot/issues/65