### PR TITLE
Clarifying name and use of React env config.

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 
-const GLOBALS = {
+const REACT_BUILD_ENV = {
   'process.env.NODE_ENV': JSON.stringify('development'),
   __DEV__: true
 };
@@ -22,7 +22,7 @@ export default {
     filename: 'bundle.js'
   },
   plugins: [
-    new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.html
+    new webpack.DefinePlugin(REACT_BUILD_ENV), // Tells React to build in either dev or prod modes. https://facebook.github.io/react/downloads.html (See bottom)
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new HtmlWebpackPlugin({     // Create HTML file that includes references to bundled CSS and JS.


### PR DESCRIPTION
1. "GLOBALS" is ambiguous, particularly since its only use is to configure the React environment. I don't really see a reason to abstract this at all, as opposed to just inlining the object in the call to `webpack.DefinePlugin`.

2. Clarified the comment on line 25 to indicate that the statement before it sets the build to either mode, not just prod.

Note: There should probably be a comment on line 6 to explain the need to `JSON.stringify` a string. I'm not sure of the reason, so I couldn't add the comment myself.