### PR TITLE
added stage1 babelrc settings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     "es2015",
-    "react"
+    "react",
+    "stage-1"
   ],
   "env": {
     "development": {


### PR DESCRIPTION
According to https://babeljs.io/docs/plugins/preset-stage-1/, which is included in dev-dependencies, you need to specify stage1 in .babelrc to work. I assume, you only forgot this, since it is already included.

After adding, features like {var1, var2, ...other} started to work.