### PR TITLE
"lint" script should use the locally installed esw

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "npm-run-all --parallel test:watch open:src lint:watch",
     "open:src": "babel-node tools/srcServer.js",
     "open:dist": "babel-node tools/distServer.js",
-    "lint": "esw webpack.config.* src tools --color",
+    "lint": "node_modules/.bin/esw webpack.config.* src tools --color",
     "lint:watch": "npm run lint -- --watch",
     "clean-dist": "npm run remove-dist && mkdir dist",
     "remove-dist": "rimraf ./dist",


### PR DESCRIPTION
As eslint-watch package is part of the dependencies, esw should be referred to the local installation.
Currently, the "lint" script is using the globally installed version, if avalable:
`"lint": "esw webpack.config.* src tools --color"`

This small update includes: 
`"lint": "node_modules/.bin/esw webpack.config.* src tools --color"`