### PR TITLE
Move chunk injection into template

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -18,8 +18,15 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta charset="utf-8"/>
   <title>Fusion Starter</title>
+  <% for (var css in htmlWebpackPlugin.files.css) { %>
+  <link href="/<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+  <% } %>
 </head>
 <body>
 <div id="app"></div>
+
+<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+<script src="/<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+<% } %>
 </body>
 </html>

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -31,7 +31,8 @@ export default {
         removeComments: true,
         collapseWhitespace: true
       },
-      inject: true
+      // injection is now handled in the template to allow for absolute paths, fixes issue with nested routes
+      inject: false
     })
   ],
   module: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -51,7 +51,8 @@ export default {
         minifyCSS: true,
         minifyURLs: true
       },
-      inject: true,
+      // injection is now handled in the template to allow for absolute paths, fixes issue with nested routes
+      inject: false,
       // Note that you can add custom options here if you need to handle other custom logic in index.html
       // To track JavaScript errors via TrackJS, sign up for a free trial at TrackJS.com and enter your token below.
       trackJSToken: ''


### PR DESCRIPTION
I came across an issue in a different project that uses `html-webpack-plugin` that with the `inject` flag set to `true` the path to bundle is relative and causes issues with nested paths. 

I tested this in slingshot by navigating to http://localhost:3000/demo/test, I expected to see the 404 page, but with the relative path to `bundle.js` it returned a blank page. 

I used [this example template](https://github.com/jaketrent/html-webpack-template/blob/86f285d5c790a6c15263f5cc50fd666d51f974fd/index.html) to inject the chunks and properly made them absolute. 