### PR TITLE
Fixes bundle.js not loading on nested page refresh

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -15,6 +15,7 @@ export default {
   target: 'web', // necessary per https://webpack.github.io/docs/testing.html#compile-and-test
   output: {
     path: `${__dirname}/src`, // Note: Physical files are only output by the production build task `npm run build`.
+    publicPath: '/',
     filename: 'bundle.js'
   },
   plugins: [


### PR DESCRIPTION
1.  Given a nested route: `<Route path="course/:id" component={ManageCoursePage} />`
2.  If the user tries to go directly to `http://localhost:3000/course/4` in their browser.
3.  bundle.js will attempt to load from `http://localhost:3000/course/bundle.js` and get a 404 error.

Found this fix here:  https://github.com/ampedandwired/html-webpack-plugin/issues/98

If you would like an example project with this behavior, please let me know and I will post one.