### PR TITLE
Include Redux Thunk Middleware

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -63,6 +63,7 @@ Unfortunately, scripts in package.json can't be commented inline because the JSO
 |react-redux|Redux library for connecting React components to Redux |
 |react-router|React library for routing |
 |redux|Library for unidirectional data flows |
+|redux-thunk|Middleware for redux that allows actions to be declared as functions |
 |babel-cli|Babel Command line interface |
 |babel-core|Babel Core for transpiling the new JavaScript to old |
 |babel-loader|Adds Babel support to Webpack |

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-redux": "4.4.5",
     "react-router": "2.6.1",
     "react-router-redux": "4.0.5",
-    "redux": "3.5.2"
+    "redux": "3.5.2",
+    "redux-thunk": "2.1.0"
   },
   "devDependencies": {
     "autoprefixer": "6.4.0",

--- a/src/actions/fuelSavingsActions.js
+++ b/src/actions/fuelSavingsActions.js
@@ -1,7 +1,12 @@
 import * as types from '../constants/actionTypes';
 
+// example of a thunk using the redux-thunk middleware
 export function saveFuelSavings(settings) {
-  return {type: types.SAVE_FUEL_SAVINGS, settings};
+  return function (dispatch) {
+    // thunks allow for pre-processing actions, calling apis, and dispatching multiple actions
+    // in this case at this point we could call a service that would persist the fuel savings
+    return dispatch({type: types.SAVE_FUEL_SAVINGS, settings});
+  };
 }
 
 export function calculateFuelSavings(settings, fieldName, value) {

--- a/src/actions/fuelSavingsActions.spec.js
+++ b/src/actions/fuelSavingsActions.spec.js
@@ -1,6 +1,10 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import * as ActionCreators from './fuelSavingsActions';
 import * as ActionTypes from '../constants/actionTypes';
+
+chai.use(sinonChai);
 
 describe('Actions', () => {
   const appState = {
@@ -21,13 +25,18 @@ describe('Actions', () => {
   };
 
   it('should create an action to save fuel savings', () => {
+    const dispatch = sinon.spy();
     const expected = {
       type: ActionTypes.SAVE_FUEL_SAVINGS,
       settings: appState
     };
 
-    expect(ActionCreators.saveFuelSavings(appState)).to.deep.equal(expected); // Notice use of deep because it's a nested object
-    // expect(ActionCreators.saveFuelSavings(appState)).to.equal(expected); // Fails. Not deeply equal
+    // we expect this to return a function since it is a thunk
+    expect(typeof (ActionCreators.saveFuelSavings(appState))).to.equal('function');
+    // then we simulate calling it with dispatch as the store would do
+    ActionCreators.saveFuelSavings(appState)(dispatch);
+    // finally assert that the dispatch was called with our expected action
+    expect(dispatch).to.have.been.calledWith(expected);
   });
 
   it('should create an action to calculate fuel savings', () => {
@@ -41,6 +50,7 @@ describe('Actions', () => {
       value
     };
 
-    expect(ActionCreators.calculateFuelSavings(appState, fieldName, value)).to.deep.equal(expected);
+    expect(ActionCreators.calculateFuelSavings(appState, fieldName, value)).to.deep.equal(expected); // Notice use of deep because it's a nested object
+    // expect(ActionCreators.calculateFuelSavings(appState, fieldName, value)).to.equal(expected); // Fails. Not deeply equal
   });
 });

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -2,12 +2,21 @@
 // This boilerplate file is likely to be the same for each project that uses Redux.
 // With Redux, the actual stores are in /reducers.
 
-import {createStore, compose} from 'redux';
+import {createStore, compose, applyMiddleware} from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-  const store = createStore(rootReducer, initialState, compose(
+  const middewares = [
     // Add other middleware on this line...
+
+    // thunk middleware can also accept an extra argument to be passed to each thunk action
+    // https://github.com/gaearon/redux-thunk#injecting-a-custom-argument
+    thunkMiddleware,
+  ];
+
+  const store = createStore(rootReducer, initialState, compose(
+    applyMiddleware(...middewares),
     window.devToolsExtension ? window.devToolsExtension() : f => f // add support for Redux dev tools
     )
   );

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,6 +1,18 @@
-import {createStore} from 'redux';
+import {createStore, compose, applyMiddleware} from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-  return createStore(rootReducer, initialState);
+  const middewares = [
+    // Add other middleware on this line...
+
+    // thunk middleware can also accept an extra argument to be passed to each thunk action
+    // https://github.com/gaearon/redux-thunk#injecting-a-custom-argument
+    thunkMiddleware,
+  ];
+
+  return createStore(rootReducer, initialState, compose(
+    applyMiddleware(...middewares)
+    )
+  );
 }


### PR DESCRIPTION
Based on the conversation in #121, I added the thunk middleware with proper documentation and updated the save action to be a thunk as a demo of both what it looks like and how to test. 

Let me know if the documentation is sufficient and clear. 