### PR TITLE
Proposal: Include Selectors

### DIFF
--- a/src/containers/FuelSavingsPage.js
+++ b/src/containers/FuelSavingsPage.js
@@ -1,8 +1,9 @@
-import React, {PropTypes} from 'react';
-import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import * as actions from '../actions/fuelSavingsActions';
 import FuelSavingsForm from '../components/FuelSavingsForm';
+import { getFuelSavings } from '../selectors/FuelSavings';
 
 export const FuelSavingsPage = (props) => {
   return (
@@ -21,7 +22,7 @@ FuelSavingsPage.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    fuelSavings: state.fuelSavings
+    fuelSavings: getFuelSavings(state)
   };
 }
 

--- a/src/reducers/fuelSavingsReducer.js
+++ b/src/reducers/fuelSavingsReducer.js
@@ -1,6 +1,4 @@
 import {SAVE_FUEL_SAVINGS, CALCULATE_FUEL_SAVINGS} from '../constants/actionTypes';
-import calculator from '../utils/fuelSavingsCalculator';
-import dateHelper from '../utils/dateHelper';
 import objectAssign from 'object-assign';
 import initialState from './initialState';
 
@@ -16,17 +14,13 @@ export default function fuelSavingsReducer(state = initialState.fuelSavings, act
     case SAVE_FUEL_SAVINGS:
       // For this example, just simulating a save by changing date modified.
       // In a real app using Redux, you might use redux-thunk and handle the async call in fuelSavingsActions.js
-      return objectAssign({}, state, {dateModified: dateHelper.getFormattedDateTime(new Date())});
+      return objectAssign({}, state, {dateModified: action.dateModified || new Date()});
 
     case CALCULATE_FUEL_SAVINGS:
       newState = objectAssign({}, state);
       newState[action.fieldName] = action.value;
-      newState.necessaryDataIsProvidedToCalculateSavings = calculator().necessaryDataIsProvidedToCalculateSavings(newState);
-      newState.dateModified = dateHelper.getFormattedDateTime(new Date());
-
-      if (newState.necessaryDataIsProvidedToCalculateSavings) {
-        newState.savings = calculator().calculateSavings(newState);
-      }
+      // pulling dateModified from the action will help in tests, but should not be exposed through action creators
+      newState.dateModified = action.dateModified || new Date();
 
       return newState;
 

--- a/src/reducers/fuelSavingsReducer.spec.js
+++ b/src/reducers/fuelSavingsReducer.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import * as ActionTypes from '../constants/actionTypes';
 import reducer from './fuelSavingsReducer';
-import dateHelper from '../utils/dateHelper';
 
 describe('Reducers::FuelSavings', () => {
+  const now = new Date();
   const getInitialState = () => {
     return {
       newMpg: '',
@@ -14,12 +14,6 @@ describe('Reducers::FuelSavings', () => {
       milesDrivenTimeframe: 'week',
       displayResults: false,
       dateModified: null,
-      necessaryDataIsProvidedToCalculateSavings: false,
-      savings: {
-        monthly: 0,
-        annual: 0,
-        threeYear: 0
-      }
     };
   };
 
@@ -33,12 +27,6 @@ describe('Reducers::FuelSavings', () => {
       milesDrivenTimeframe: 'week',
       displayResults: false,
       dateModified: null,
-      necessaryDataIsProvidedToCalculateSavings: false,
-      savings: {
-        monthly: 0,
-        annual: 0,
-        threeYear: 0
-      }
     };
   };
 
@@ -51,8 +39,8 @@ describe('Reducers::FuelSavings', () => {
   });
 
   it('should handle SAVE_FUEL_SAVINGS', () => {
-    const action = { type: ActionTypes.SAVE_FUEL_SAVINGS, settings: getAppState() };
-    const expected = Object.assign(getAppState(), {dateModified: dateHelper.getFormattedDateTime(new Date())});
+    const action = { type: ActionTypes.SAVE_FUEL_SAVINGS, settings: getAppState(), dateModified: now };
+    const expected = Object.assign(getAppState(), {dateModified: now});
 
     expect(reducer(getAppState(), action)).to.deep.equal(expected);
   });
@@ -61,9 +49,7 @@ describe('Reducers::FuelSavings', () => {
     const action = { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: getAppState(), fieldName: 'newMpg', value: 30 };
 
     const expectedMpg = 30;
-    const expectedSavings = { monthly: '$43.33', annual: '$519.96', threeYear: '$1,559.88' };
 
     expect(reducer(getAppState(), action).newMpg).to.equal(expectedMpg);
-    expect(reducer(getAppState(), action).savings).to.deep.equal(expectedSavings);
   });
 });

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -8,11 +8,5 @@ export default {
     milesDrivenTimeframe: 'week',
     displayResults: false,
     dateModified: null,
-    necessaryDataIsProvidedToCalculateSavings: false,
-    savings: {
-      monthly: 0,
-      annual: 0,
-      threeYear: 0
-    }
   }
 };

--- a/src/selectors/FuelSavings.js
+++ b/src/selectors/FuelSavings.js
@@ -1,0 +1,11 @@
+import calculator from '../utils/fuelSavingsCalculator';
+import dateHelper from '../utils/dateHelper';
+
+// select is pass all of state, this will allow for a smoother refactor to a library such as reselect in the future
+export const getFuelSavings = ({ fuelSavings }) => (
+  // returning clone to ensure no mutations
+  Object.assign({}, fuelSavings, {
+    dateModified: dateHelper.getFormattedDateTime(fuelSavings.dateModified),
+    savings: calculator().necessaryDataIsProvidedToCalculateSavings(fuelSavings) ? calculator().calculateSavings(fuelSavings) : fuelSavings.savings,
+  })
+);

--- a/src/store/store.spec.js
+++ b/src/store/store.spec.js
@@ -7,16 +7,18 @@ import dateHelper from '../utils/dateHelper';
 import initialState from '../reducers/initialState';
 
 describe('Store', () => {
+  const now = new Date();
+
   it('should display results when necessary data is provided', () => {
     const store = createStore(rootReducer, initialState);
 
     const actions = [
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'newMpg', value: 20 },
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'tradeMpg', value: 10 },
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'newPpg', value: 1.50 },
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'tradePpg', value: 1.50 },
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'milesDriven', value: 100 },
-      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), fieldName: 'milesDrivenTimeframe', value: 'month' }
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'newMpg', value: 20 },
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'tradeMpg', value: 10 },
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'newPpg', value: 1.50 },
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'tradePpg', value: 1.50 },
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'milesDriven', value: 100 },
+      { type: ActionTypes.CALCULATE_FUEL_SAVINGS, settings: store.getState(), dateModified: now, fieldName: 'milesDrivenTimeframe', value: 'month' }
     ];
     actions.forEach(action => store.dispatch(action));
 
@@ -29,9 +31,7 @@ describe('Store', () => {
       milesDriven: 100,
       milesDrivenTimeframe: 'month',
       displayResults: false,
-      dateModified: dateHelper.getFormattedDateTime(new Date()),
-      necessaryDataIsProvidedToCalculateSavings: true,
-      savings: calculator().calculateSavings(store.getState().fuelSavings)
+      dateModified: now,
     };
 
     expect(actual.fuelSavings).to.deep.equal(expected);


### PR DESCRIPTION
I think selectors are really awesome for separating state from components and preform calculations. 

I started on this effort since I saw both a need from the app, and I think it is a good practice to not store calculated values in the store. 

That being said, some of the logic in the app counter acts these changes, so I paused the effort to make sure this goes in the right direction. Additionally, these changes may benefit from including `redux-thunk` (#232).

I wanted it to be an issue, but as a PR it is simpler to compare. 