### PR TITLE
Fix node version check

### DIFF
--- a/tools/nodeVersionCheck.js
+++ b/tools/nodeVersionCheck.js
@@ -1,9 +1,10 @@
 /* eslint-disable */
 var exec = require('child_process').exec;
-exec('node -v', function (err, stdout, stderr) {
+
+exec('node -v', function (err, stdout) {
   if (err) throw err;
-  if (parseFloat(stdout) < 4) {
-    throw new Error('ERROR: React Slingshot requires node 4.0 or greater.');
-    process.exit(1);
+
+  if (parseFloat(stdout.slice(1)) < 4) {
+    throw new Error('React Slingshot requires node 4.0 or greater.');
   }
 });


### PR DESCRIPTION
This PR

* [x] removes unused `stderr` param
* [x] removes unreachable `process.exit(1)`
* [x] throw error on unmet node version requirement 

>A floating point number parsed from the given string. If the first character cannot be converted to a number, NaN is returned.

`node -v` returns version number prefixed with `v`, which makes `parseFloat` return `NaN`.
