### PR TITLE
Use "babel-eslint" as parser for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   "plugins": [
     "react"
   ],
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "autoprefixer": "6.4.0",
     "babel-cli": "6.14.0",
     "babel-core": "6.14.0",
+    "babel-eslint": "7.0.0",
     "babel-loader": "6.2.5",
     "babel-plugin-react-display-name": "2.0.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",


### PR DESCRIPTION
With Babel we can use a lot of syntax sugar - it's cool, but ESLint ain't able to fit the things.

For instance, class properties aren't available. More information can be found here: https://github.com/babel/babel-eslint/issues/312