### PR TITLE
Prompt before deleting git repo in setup script - fixes #284

### DIFF
--- a/tools/setup/setup.js
+++ b/tools/setup/setup.js
@@ -7,74 +7,88 @@ var prompts = require('./setupPrompts');
 
 var chalkSuccess = chalk.green;
 var chalkProcessing = chalk.blue;
+var chalkWarn = chalk.red;
 
 /* eslint-disable no-console */
 
 console.log(chalkSuccess('Dependencies installed.'));
 
-// remove the original git repository
-rimraf('.git', error => {
-  if (error) throw new Error(error);
-});
-console.log(chalkSuccess('Original Git repository removed.\n'));
-
-// prompt the user for updates to package.json
-console.log(chalkProcessing('Updating package.json settings:'));
 prompt.start();
-prompt.get(prompts, function(err, result) {
-  // parse user responses
-  // default values provided for fields that will cause npm to complain if left empty
-  const responses = [
-    {
-      key: 'name',
-      value: result.projectName || 'new-project'
-    },
-    {
-      key: 'version',
-      value: result.version || '0.1.0'
-    },
-    {
-      key: 'author',
-      value: result.author
-    },
-    {
-      key: 'license',
-      value: result.license || 'MIT'
-    },
-    {
-      key: 'description',
-      value: result.description
-    },
-    // simply use an empty URL here to clear the existing repo URL
-    {
-      key: 'url',
-      value: ''
-    }
-  ];
 
-  // update package.json with the user's values
-  responses.forEach(res => {
+console.log(chalkWarn("WARNING:  Preparing to delete local git repository..."));
+prompt.get([{name: 'deleteGit', description: "Delete the git repository?  YES to continue or NO to skip."}], function(err, result) {
+  var deleteGit;
+
+  if (err) {
+    process.exit(1);
+  }
+
+  deleteGit = result.deleteGit.toUpperCase();
+  if (deleteGit === 'Y' || deleteGit === "YES") {
+    // remove the original git repository
+    rimraf('.git', error => {
+      if (error) throw new Error(error);
+      console.log(chalkSuccess('Original Git repository removed.\n'));
+    });
+  }
+
+  console.log(chalkProcessing('Updating package.json settings:'));
+
+  prompt.get(prompts, function(err, result) {
+    // parse user responses
+    // default values provided for fields that will cause npm to complain if left empty
+    const responses = [
+      {
+        key: 'name',
+        value: result.projectName || 'new-project'
+      },
+      {
+        key: 'version',
+        value: result.version || '0.1.0'
+      },
+      {
+        key: 'author',
+        value: result.author
+      },
+      {
+        key: 'license',
+        value: result.license || 'MIT'
+      },
+      {
+        key: 'description',
+        value: result.description
+      },
+      // simply use an empty URL here to clear the existing repo URL
+      {
+        key: 'url',
+        value: ''
+      }
+    ];
+
+    // update package.json with the user's values
+    responses.forEach(res => {
+      replace({
+        regex: `("${res.key}"): "(.*?)"`,
+        replacement: `$1: "${res.value}"`,
+        paths: ['package.json'],
+        recursive: false,
+        silent: true
+      });
+    });
+
+    // reset package.json 'keywords' field to empty state
     replace({
-      regex: `("${res.key}"): "(.*?)"`,
-      replacement: `$1: "${res.value}"`,
+      regex: /"keywords": \[[\s\S]+\]/,
+      replacement: `"keywords": []`,
       paths: ['package.json'],
       recursive: false,
       silent: true
     });
-  });
 
-  // reset package.json 'keywords' field to empty state
-  replace({
-    regex: /"keywords": \[[\s\S]+\]/,
-    replacement: `"keywords": []`,
-    paths: ['package.json'],
-    recursive: false,
-    silent: true
-  });
-
-  // remove all setup scripts from the 'tools' folder
-  console.log(chalkSuccess('\nSetup complete! Cleaning up...\n'));
-  rimraf('./tools/setup', error => {
-    if (error) throw new Error(error);
+    // remove all setup scripts from the 'tools' folder
+    console.log(chalkSuccess('\nSetup complete! Cleaning up...\n'));
+    rimraf('./tools/setup', error => {
+      if (error) throw new Error(error);
+    });
   });
 });


### PR DESCRIPTION
It looks like a lot more changed than it did, but most of this was just moving the package.json modification code to be part of the callback for the git delete prompt handler.  Warn the user before deleting and allow them to skip deleting the git repo, but continue modifying package.json either way.  