### PR TITLE
Nest prompts within git removal callback

### DIFF
--- a/tools/setup/setup.js
+++ b/tools/setup/setup.js
@@ -29,66 +29,66 @@ prompt.get([{name: 'deleteGit', description: "Delete the git repository?  YES to
     rimraf('.git', error => {
       if (error) throw new Error(error);
       console.log(chalkSuccess('Original Git repository removed.\n'));
-    });
-  }
 
-  console.log(chalkProcessing('Updating package.json settings:'));
+      console.log(chalkProcessing('Updating package.json settings:'));
 
-  prompt.get(prompts, function(err, result) {
-    // parse user responses
-    // default values provided for fields that will cause npm to complain if left empty
-    const responses = [
-      {
-        key: 'name',
-        value: result.projectName || 'new-project'
-      },
-      {
-        key: 'version',
-        value: result.version || '0.1.0'
-      },
-      {
-        key: 'author',
-        value: result.author
-      },
-      {
-        key: 'license',
-        value: result.license || 'MIT'
-      },
-      {
-        key: 'description',
-        value: result.description
-      },
-      // simply use an empty URL here to clear the existing repo URL
-      {
-        key: 'url',
-        value: ''
-      }
-    ];
+      prompt.get(prompts, function(err, result) {
+        // parse user responses
+        // default values provided for fields that will cause npm to complain if left empty
+        const responses = [
+          {
+            key: 'name',
+            value: result.projectName || 'new-project'
+          },
+          {
+            key: 'version',
+            value: result.version || '0.1.0'
+          },
+          {
+            key: 'author',
+            value: result.author
+          },
+          {
+            key: 'license',
+            value: result.license || 'MIT'
+          },
+          {
+            key: 'description',
+            value: result.description
+          },
+          // simply use an empty URL here to clear the existing repo URL
+          {
+            key: 'url',
+            value: ''
+          }
+        ];
 
-    // update package.json with the user's values
-    responses.forEach(res => {
-      replace({
-        regex: `("${res.key}"): "(.*?)"`,
-        replacement: `$1: "${res.value}"`,
-        paths: ['package.json'],
-        recursive: false,
-        silent: true
+        // update package.json with the user's values
+        responses.forEach(res => {
+          replace({
+            regex: `("${res.key}"): "(.*?)"`,
+            replacement: `$1: "${res.value}"`,
+            paths: ['package.json'],
+            recursive: false,
+            silent: true
+          });
+        });
+
+        // reset package.json 'keywords' field to empty state
+        replace({
+          regex: /"keywords": \[[\s\S]+\]/,
+          replacement: `"keywords": []`,
+          paths: ['package.json'],
+          recursive: false,
+          silent: true
+        });
+
+        // remove all setup scripts from the 'tools' folder
+        console.log(chalkSuccess('\nSetup complete! Cleaning up...\n'));
+        rimraf('./tools/setup', error => {
+          if (error) throw new Error(error);
+        });
       });
     });
-
-    // reset package.json 'keywords' field to empty state
-    replace({
-      regex: /"keywords": \[[\s\S]+\]/,
-      replacement: `"keywords": []`,
-      paths: ['package.json'],
-      recursive: false,
-      silent: true
-    });
-
-    // remove all setup scripts from the 'tools' folder
-    console.log(chalkSuccess('\nSetup complete! Cleaning up...\n'));
-    rimraf('./tools/setup', error => {
-      if (error) throw new Error(error);
-    });
-  });
+  }
 });


### PR DESCRIPTION
Given the existing structure, the "Original Git repository removed" message can (and on my machine *did*) appear after the prompt for the new project name. It's green styling arrested my attention from the prompt causing me to believe the process had hung. By moving the prompts inside the callback, git removal will always be completed before the prompting begins.

The confusing message is included below:

![message screenshot](http://imgur.com/n0GqQED.png)

> Dependencies installed.
> WARNING:  Preparing to delete local git repository...
> prompt: Delete the git repository?  YES to continue or NO to skip.:  YES
> Updating package.json settings:
> prompt: Project name (default: new-project):  Original Git repository removed.
