### PR TITLE
Fix lint warning introduced by #316

### DIFF
--- a/tools/removeDemo.js
+++ b/tools/removeDemo.js
@@ -50,8 +50,8 @@ function createFile(file) {
 
 function removePackageJsonScriptEntry(scriptName) {
   const packageJsonPath = './package.json';
-  var fileData = fs.readFileSync(packageJsonPath);
-  var content = JSON.parse(fileData);
+  let fileData = fs.readFileSync(packageJsonPath);
+  let content = JSON.parse(fileData);
   delete content.scripts[scriptName];
   fs.writeFileSync(packageJsonPath,
     JSON.stringify(content, null, 2) + '\n');


### PR DESCRIPTION
There were a couple of eslint warnings related to 'var' usage in the previous commit for #316. (Sorry! Old habits die hard. Probably would have shown up in the appveyor output if it had not glitched out? Or if I had paid more attention on my own local build.)