### PR TITLE
[WIP] Change dist server to run on port 4000

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "setup": "node tools/setup/setupMessage.js && npm install && node tools/setup/setup.js",
     "remove-demo": "babel-node tools/removeDemo.js",
     "start-message": "babel-node tools/startMessage.js",
-    "prestart": "npm-run-all --parallel start-message remove-dist",
+    "prestart": "npm-run-all --parallel start-message",
     "start": "npm-run-all --parallel test:watch open:src lint:watch",
     "open:src": "babel-node tools/srcServer.js",
     "open:dist": "babel-node tools/distServer.js",

--- a/tools/distServer.js
+++ b/tools/distServer.js
@@ -11,9 +11,9 @@ console.log(chalkProcessing('Opening production build...'));
 
 // Run Browsersync
 browserSync({
-  port: 3000,
+  port: 4000,
   ui: {
-    port: 3001
+    port: 4001
   },
   server: {
     baseDir: 'dist'


### PR DESCRIPTION
I think it makes sense to want to build while dev server is running(I do this periodically). Unfortunately, the dist and dev server run on the same port so this fails. This PR changes the port the dist server runs on so both can run at the same time.

Questions
==

* Is this a desired change? I'm not sure if there was a reason for having them on the same port in the first place
* Is port `4000` ok? I'm happy to change to something else.

Issues
==
Executing `yarn start` or `npm start` will remove the dist folder. This is not good if the dist server is running and its files are getting deleted. My solution is to not execute `remove-dist` when the dev server is started but that depends on why it currently happens.
