### PR TITLE
Fix appveyor cahce path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - yarn
 
 cache:
-  - "%LOCALAPPDATA%/Yarn"
+  - "%LOCALAPPDATA%\\Yarn"
 
 # Post-install test scripts.
 test_script:


### PR DESCRIPTION
When I was playing with the jest-migration I noticed an error that path was not defined. It does not stop the build from being successful and I did not see the error in any other builds. I still couldn't leave it untouched.