### PR TITLE
Updated react-hot-loader to correct package version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "postcss-loader": "1.2.1",
     "prompt": "1.0.0",
     "react-addons-test-utils": "15.4.1",
-    "react-hot-loader": "3.0.0",
+    "react-hot-loader": "3.0.0-beta.6",
     "redux-immutable-state-invariant": "1.2.4",
     "replace": "0.3.0",
     "rimraf": "2.5.4",


### PR DESCRIPTION
`npm install` would fail to execute otherwise.