### PR TITLE
Add redux-logger to dev store configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-hot-loader": "3.0.0-beta.6",
     "react-test-renderer": "15.5.4",
     "redux-immutable-state-invariant": "1.2.4",
+    "redux-logger": "3.0.6",
     "replace": "0.3.0",
     "rimraf": "2.5.4",
     "sass-loader": "6.0.2",

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,6 +1,7 @@
 import {createStore, compose, applyMiddleware} from 'redux';
 import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
 import thunk from 'redux-thunk';
+import logger from 'redux-logger';
 import rootReducer from '../reducers';
 
 function configureStoreProd(initialState) {
@@ -28,6 +29,9 @@ function configureStoreDev(initialState) {
     // thunk middleware can also accept an extra argument to be passed to each thunk action
     // https://github.com/gaearon/redux-thunk#injecting-a-custom-argument
     thunk,
+
+    // Middleware to print Redux store updates to the console
+    logger,
   ];
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // add support for Redux dev tools


### PR DESCRIPTION
This change adds the redux-logger package to devDependencies and also to the Redux dev store configuration for better debugging.