### PR TITLE
Upgrade to webpack 3, and upgrade all other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,54 +41,54 @@
     "redux-thunk": "2.1.0"
   },
   "devDependencies": {
-    "autoprefixer": "6.5.4",
-    "babel-cli": "6.18.0",
-    "babel-core": "6.20.0",
-    "babel-eslint": "7.1.1",
-    "babel-jest": "18.0.0",
-    "babel-loader": "6.2.10",
-    "babel-plugin-transform-react-constant-elements": "6.9.1",
-    "babel-plugin-transform-react-remove-prop-types": "0.2.11",
-    "babel-polyfill": "6.20.0",
-    "babel-preset-env": "1.3.2",
-    "babel-preset-react": "6.16.0",
+    "autoprefixer": "7.1.2",
+    "babel-cli": "6.24.1",
+    "babel-core": "6.25.0",
+    "babel-eslint": "7.2.3",
+    "babel-jest": "20.0.3",
+    "babel-loader": "7.1.1",
+    "babel-plugin-transform-react-constant-elements": "6.23.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.6",
+    "babel-polyfill": "6.23.0",
+    "babel-preset-env": "1.6.0",
+    "babel-preset-react": "6.24.1",
     "babel-preset-react-hmre": "1.1.1",
-    "babel-preset-stage-1": "6.16.0",
-    "browser-sync": "2.18.5",
-    "chalk": "1.1.3",
+    "babel-preset-stage-1": "6.24.1",
+    "browser-sync": "2.18.12",
+    "chalk": "2.0.1",
     "connect-history-api-fallback": "1.3.0",
-    "coveralls": "2.11.15",
-    "css-loader": "0.26.1",
-    "enzyme": "2.8.2",
-    "eslint": "3.12.2",
-    "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-react": "6.8.0",
-    "eslint-watch": "2.1.14",
-    "extract-text-webpack-plugin": "2.1.0",
-    "file-loader": "0.9.0",
-    "html-webpack-plugin": "2.24.1",
+    "coveralls": "2.13.1",
+    "css-loader": "0.28.4",
+    "enzyme": "2.9.1",
+    "eslint": "4.2.0",
+    "eslint-plugin-import": "2.7.0",
+    "eslint-plugin-react": "7.1.0",
+    "eslint-watch": "3.1.2",
+    "extract-text-webpack-plugin": "3.0.0-rc.2",
+    "file-loader": "0.11.2",
+    "html-webpack-plugin": "2.29.0",
     "identity-obj-proxy": "3.0.0",
-    "jest": "18.1.0",
+    "jest": "20.0.4",
     "json-loader": "0.5.4",
     "mockdate": "2.0.1",
-    "node-sass": "4.5.2",
-    "npm-run-all": "3.1.2",
+    "node-sass": "4.5.3",
+    "npm-run-all": "4.0.2",
     "opn-cli": "3.1.0",
     "postcss-loader": "1.2.1",
     "prompt": "1.0.0",
     "prop-types": "15.5.10",
     "react-hot-loader": "3.0.0-beta.6",
     "react-test-renderer": "15.5.4",
-    "redux-immutable-state-invariant": "1.2.4",
+    "redux-immutable-state-invariant": "2.0.0",
     "replace": "0.3.0",
-    "rimraf": "2.5.4",
-    "sass-loader": "6.0.2",
-    "style-loader": "0.13.1",
-    "url-loader": "0.5.7",
-    "webpack": "2.2.1",
-    "webpack-bundle-analyzer": "2.1.1",
-    "webpack-dev-middleware": "1.9.0",
-    "webpack-hot-middleware": "2.17.1",
+    "rimraf": "2.6.1",
+    "sass-loader": "6.0.6",
+    "style-loader": "0.18.2",
+    "url-loader": "0.5.9",
+    "webpack": "3.1.0",
+    "webpack-bundle-analyzer": "2.8.2",
+    "webpack-dev-middleware": "1.11.0",
+    "webpack-hot-middleware": "2.18.2",
     "webpack-md5-hash": "0.0.5"
   },
   "keywords": [
@@ -117,16 +117,10 @@
     }
   },
   "babel": {
-    "presets": [
-      "react",
-      "stage-1"
-    ],
+    "presets": ["react", "stage-1"],
     "env": {
       "development": {
-        "presets": [
-          "env",
-          "react-hmre"
-        ]
+        "presets": ["env", "react-hmre"]
       },
       "production": {
         "presets": [
@@ -145,9 +139,7 @@
         ]
       },
       "test": {
-        "presets": [
-          "env"
-        ]
+        "presets": ["env"]
       }
     }
   },
@@ -158,9 +150,7 @@
       "plugin:import/errors",
       "plugin:import/warnings"
     ],
-    "plugins": [
-      "react"
-    ],
+    "plugins": ["react"],
     "parser": "babel-eslint",
     "parserOptions": {
       "ecmaVersion": 6,
@@ -182,10 +172,7 @@
       "no-console": 1,
       "no-debugger": 1,
       "no-var": 1,
-      "semi": [
-        1,
-        "always"
-      ],
+      "semi": [1, "always"],
       "no-trailing-spaces": 0,
       "eol-last": 0,
       "no-underscore-dangle": 0,
@@ -201,9 +188,7 @@
       "react/forbid-prop-types": [
         1,
         {
-          "forbid": [
-            "any"
-          ]
+          "forbid": ["any"]
         }
       ],
       "react/jsx-boolean-value": 0,


### PR DESCRIPTION
Haven't done a ton of testing on this branch yet, but so far it looks ok. 

This will upgrade to **Webpack 3** and _upgrades a ton of other packages_ too. If you'd like, I can try to separate those dependency upgrades out, but figured it'd be useful to get everything up to the latest versions.

Resolves #442 
