### PR TITLE
Revert PR #450

### DIFF
--- a/tools/setup/setupPrompts.js
+++ b/tools/setup/setupPrompts.js
@@ -3,7 +3,7 @@ module.exports = [
   {
     name: 'projectName',
     description: 'Project name (default: new-project)',
-    pattern: /^[^._][a-z0-9\.\-_~]+$/,
+    pattern: /^[^._][a-z0-9-_~]+$/,
     message: 'Limited to: lowercase letters, numbers, period, hyphen, ' +
     'underscore, and tilde; cannot begin with period or underscore.'
   },


### PR DESCRIPTION
Removed change that removed additional dashes in npm test scripts in favor of adding jest-cli as a devDep.

This commit instead focusses on issue 2 from #449 where setupPrompts.js had a bug that caused start script to fail.