### PR TITLE
Add a babel plugin transform-class-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
           "react",
           "react-hmre",
           "stage-1"
+        ],
+        "plugins": [
+          "transform-class-properties"
         ]
       },
       "production": {
@@ -152,6 +155,7 @@
           "stage-1"
         ],
         "plugins": [
+          "transform-class-properties",
           "transform-react-constant-elements",
           "transform-react-remove-prop-types"
         ]


### PR DESCRIPTION
Add the mentioned plugin for both production and development usage
as it's become second to standard in React to prevent people from using the bind method.