### PR TITLE
Removed double hyphen from "jest -- --watch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:CI": "babel-node tools/testCi.js",
     "test:cover": "npm run test -- --coverage ",
     "test:cover:CI": "npm run test:CI -- --coverage && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js",
-    "test:watch": "jest -- --watch",
+    "test:watch": "jest --watch",
     "open:cover": "npm run test:cover && opn ./coverage/lcov-report/index.html",
     "analyze-bundle": "babel-node ./tools/analyzeBundle.js"
   },


### PR DESCRIPTION
I was getting the following output when running "npm start -s" and the app wasn't starting. I was only able to run it after changing it to "jest --watch".

```
Starting app in dev mode...
No tests found
In /Users/paulo/Development/react-slingshot
  50 files checked.
  testMatch: **/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x) - 12 matches
  testPathIgnorePatterns: /node_modules/ - 50 matches
Pattern: "--watch" - 0 matches
```