### PR TITLE
Stop excluding node_modules for styles

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -96,7 +96,6 @@ export default {
       },
       {
         test: /(\.css|\.scss|\.sass)$/,
-        exclude: /node_modules/,
         use: [
           'style-loader',
           {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -128,7 +128,6 @@ export default {
       },
       {
         test: /(\.css|\.scss|\.sass)$/,
-        exclude: /node_modules/,
         use: ExtractTextPlugin.extract({
           use: [
             {


### PR DESCRIPTION
Someone pointed out they couldn't import styles from npm packages because we're excluding node_modules. This PR fixes #506