### PR TITLE
Adding docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8-alpine
+
+WORKDIR /code/
+
+EXPOSE 4000 4001
+
+COPY . .
+
+RUN npm run setup
+
+ENTRYPOINT npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM node:8-alpine
 
 WORKDIR /code/
 
-EXPOSE 4000 4001
+EXPOSE 3000 3001
 
 COPY . .
 
+RUN npm install --unsafe-perm
+
 RUN npm run setup
 
-ENTRYPOINT npm run build
+ENTRYPOINT npm start

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,0 +1,11 @@
+FROM node:8-alpine
+
+WORKDIR /code/
+
+EXPOSE 4000 4001
+
+COPY . .
+
+RUN npm run setup
+
+ENTRYPOINT npm run build

--- a/README.md
+++ b/README.md
@@ -45,8 +45,18 @@ This will run the automated build process, start up a webserver, and open the ap
 * **Install C++ Compiler**. Browser-sync requires a C++ compiler on Windows. [Visual Studio Express](https://www.visualstudio.com/en-US/products/visual-studio-express-vs) comes bundled with a free C++ compiler. Or, if you already have Visual Studio installed: Open Visual Studio and go to File -> New -> Project -> Visual C++ -> Install Visual C++ Tools for Windows Desktop. The C++ compiler is used to compile browser-sync (and perhaps other Node modules).
 
 **Try It Out With [Docker](https://www.docker.com/):**
-* `docker run -p 4000:4000 -p 4001:4001 -d docker.io/allthethings/react-slingshot`
-* Then navigate to [http://localhost:4000](http://localhost:4000) (or e.g. [http://192.168.99.100:4000](http://192.168.99.100:4000) if using [docker-machine](https://docs.docker.com/toolbox/))
+
+* **Run the image.** `docker run -p 4000:4000 -p 4001:4001 -d docker.io/allthethings/react-slingshot`
+
+**Develop With Docker (including hot reloading on `src` directory)**
+
+* **Build the image.** `docker build -t react-slingshot .`
+* **Run the image with an interactive shell and automatic removal.**
+  - `docker run -v "$(pwd)"/src:/code/src -p 3000:3000 -p 3001:3001 --name react-slingshot -it --rm react-slingshot`
+* **Or run the image in daemon mode.**
+  - `docker run -v "$(pwd)"/src:/code/src -p 3000:3000 -p 3001:3001 --name react-slingshot -d react-slingshot`
+  - remove with `docker rm -f react-slingshot`
+  - print and follow the container's logs with `docker logs --follow react-slingshot`
 
 ## Having Issues? Try these things first.
 1. Make sure you ran all steps in [Get started](https://github.com/coryhouse/react-slingshot/blob/master/README.md#get-started) including the [initial machine setup](https://github.com/coryhouse/react-slingshot#initial-machine-setup).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This will run the automated build process, start up a webserver, and open the ap
 
 **Try It Out With Docker:**
 * `docker run -p 4000:4000 -p 4001:4001 -d docker.io/allthethings/react-slingshot`
+* Then navigate to [http://localhost:4000](http://localhost:4000) (or e.g. [http://192.168.99.100:4000](http://192.168.99.100:4000) if using [docker-machine](https://docs.docker.com/toolbox/))
 
 ## Having Issues? Try these things first.
 1. Make sure you ran all steps in [Get started](https://github.com/coryhouse/react-slingshot/blob/master/README.md#get-started) including the [initial machine setup](https://github.com/coryhouse/react-slingshot#initial-machine-setup).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will run the automated build process, start up a webserver, and open the ap
 * **Install C++ Compiler**. Browser-sync requires a C++ compiler on Windows. [Visual Studio Express](https://www.visualstudio.com/en-US/products/visual-studio-express-vs) comes bundled with a free C++ compiler. Or, if you already have Visual Studio installed: Open Visual Studio and go to File -> New -> Project -> Visual C++ -> Install Visual C++ Tools for Windows Desktop. The C++ compiler is used to compile browser-sync (and perhaps other Node modules).
 
 **Try It Out With Docker:**
-* `docker run -p 4000:4000 -p 4001:4001 docker.io/allthethings/react-slingshot`
+* `docker run -p 4000:4000 -p 4001:4001 -d docker.io/allthethings/react-slingshot`
 
 ## Having Issues? Try these things first.
 1. Make sure you ran all steps in [Get started](https://github.com/coryhouse/react-slingshot/blob/master/README.md#get-started) including the [initial machine setup](https://github.com/coryhouse/react-slingshot#initial-machine-setup).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This will run the automated build process, start up a webserver, and open the ap
 * **Install [Python 2.7](https://www.python.org/downloads/)**. Some node modules may rely on node-gyp, which requires Python on Windows.
 * **Install C++ Compiler**. Browser-sync requires a C++ compiler on Windows. [Visual Studio Express](https://www.visualstudio.com/en-US/products/visual-studio-express-vs) comes bundled with a free C++ compiler. Or, if you already have Visual Studio installed: Open Visual Studio and go to File -> New -> Project -> Visual C++ -> Install Visual C++ Tools for Windows Desktop. The C++ compiler is used to compile browser-sync (and perhaps other Node modules).
 
+**Try It Out With Docker:**
+* `docker run -p 4000:4000 -p 4001:4001 docker.io/allthethings/react-slingshot`
+
 ## Having Issues? Try these things first.
 1. Make sure you ran all steps in [Get started](https://github.com/coryhouse/react-slingshot/blob/master/README.md#get-started) including the [initial machine setup](https://github.com/coryhouse/react-slingshot#initial-machine-setup).
 2. Run `npm install` - If you forget to do this, you'll see this: `babel-node: command not found`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will run the automated build process, start up a webserver, and open the ap
 * **Install [Python 2.7](https://www.python.org/downloads/)**. Some node modules may rely on node-gyp, which requires Python on Windows.
 * **Install C++ Compiler**. Browser-sync requires a C++ compiler on Windows. [Visual Studio Express](https://www.visualstudio.com/en-US/products/visual-studio-express-vs) comes bundled with a free C++ compiler. Or, if you already have Visual Studio installed: Open Visual Studio and go to File -> New -> Project -> Visual C++ -> Install Visual C++ Tools for Windows Desktop. The C++ compiler is used to compile browser-sync (and perhaps other Node modules).
 
-**Try It Out With Docker:**
+**Try It Out With [Docker](https://www.docker.com/):**
 * `docker run -p 4000:4000 -p 4001:4001 -d docker.io/allthethings/react-slingshot`
 * Then navigate to [http://localhost:4000](http://localhost:4000) (or e.g. [http://192.168.99.100:4000](http://192.168.99.100:4000) if using [docker-machine](https://docs.docker.com/toolbox/))
 


### PR DESCRIPTION
- Adding docker image files for both prod and dev use
- Adding instructions to top level README.md to:
  - Run a copy of the prod version hosted on [hub.docker](https://hub.docker.com/r/allthethings/react-slingshot/) to try out the project
  - Build and run an image that will listen to changes on the host machine (to allow developers to use an IDE on their host machine)