### PR TITLE
Remove references  .eslintrc and .babelrc from FAQ and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will run the automated build process, start up a webserver, and open the ap
 1. Make sure you ran all steps in [Get started](https://github.com/coryhouse/react-slingshot/blob/master/README.md#get-started) including the [initial machine setup](https://github.com/coryhouse/react-slingshot#initial-machine-setup).
 2. Run `npm install` - If you forget to do this, you'll see this: `babel-node: command not found`.
 3. Install the latest version of Node. Or install [Node 5.12.0](https://nodejs.org/download/release/v5.12.0/) if you're having issues on Windows. Node 6 has issues on some Windows machines.
-4. Make sure files with names that begin with a dot (.babelrc, .editorconfig, .eslintrc) are copied to the project directory root. This is easy to overlook if you copy this repository manually.
+4. Make sure files with names that begin with a dot (.editorconfig, .gitignore, .npmrc) are copied to the project directory root. This is easy to overlook if you copy this repository manually.
 5. Don't run the project from a symbolic link. It may cause issues with file watches.
 6. Delete any .eslintrc that you're storing in your user directory. Also, disable any ESLint plugin / custom rules that you've enabled within your editor. These will conflict with the ESLint rules defined in this project.
 7. Make sure you don't have NODE_ENV set to production on your machine. If you do then the [development dependencies won't be installed](https://github.com/coryhouse/react-slingshot/issues/400#issuecomment-290497767). Here's [how to check](http://stackoverflow.com/a/27939821/26180).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -75,9 +75,7 @@ Unfortunately, scripts in package.json can't be commented inline because the JSO
 ### Can you explain the folder structure?
 ```
 .
-├── .babelrc                  # Configures Babel
 ├── .editorconfig             # Configures editor rules
-├── .eslintrc                 # Configures ESLint
 ├── .gitignore                # Tells git which files to ignore
 ├── .istanbul.yml             # Configure istanbul code coverage
 ├── .npmrc                    # Configures npm to save exact by default


### PR DESCRIPTION
Both .eslintrc and .babelrc were move into package.json. As a newcomer I was confused why they are absent.