### PR TITLE
Fixing invalid SASS-Loader paths

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -113,7 +113,7 @@ export default {
           }, {
             loader: 'sass-loader',
             options: {
-              includePaths: [path.resolve(__dirname, 'src', 'scss')],
+              includePaths: [path.resolve(__dirname, 'src', 'styles')],
               sourceMap: true
             }
           }

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -144,7 +144,7 @@ export default {
           }, {
             loader: 'sass-loader',
             options: {
-              includePaths: [path.resolve(__dirname, 'src', 'scss')],
+              includePaths: [path.resolve(__dirname, 'src', 'styles')],
               sourceMap: true
             }
           }


### PR DESCRIPTION
I have found wrong path in file webpack.config.dev.js and webpack.config.prod.js in plugin sass-loader. Take a look at line 116 of this file. The problem should be in includePath parameter. I'm guessing there should be option "styles" in third parameter instead of "scss". If I'm wrong just let me know why. Thank you.

```
{
  loader: 'sass-loader',
  options: {
	includePaths: [path.resolve(__dirname, 'src', 'scss')],
	sourceMap: true
}      
```

Issue: https://github.com/coryhouse/react-slingshot/issues/594