### PR TITLE
Include yarn equivalent for existing npm configs and corresponding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ _A comprehensive starter kit for rapid application development using React._
   Regardless which NodeJS package manager you prefer, React Slingshot ships ready to go with full support for both __NPM__ and __YARN__ out of the box. Tackling a new project and wanna skip the headaches we all inevitably face when setting up a fresh development environment? If you'd prefer to jump straight into development and getting down to doing what you do best; With React Slingshot, all you need to do is run one, simple command:
 
   - __NPM:__ `npm start`
-  - __YARN:__ `yarn start`
 
   Then you're good to go!
 
@@ -57,7 +56,6 @@ _A comprehensive starter kit for rapid application development using React._
   Ready to show off your finished app to the world? Running a single command:
 
   - __NPM:__ `npm run build`
-  - __YARN:__ `yarn build`
 
   _Gets you all of this:_
 
@@ -80,10 +78,6 @@ __NPM__ \
 
   * ![](https://img.shields.io/badge/dynamic/json.svg?style=flat-square&label=npm+version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoryhouse%2Freact-slingshot%2Fmaster%2Fpackage.json&query=%24.engines.npm&colorB=orange)
 
-__YARN__ \
-  _To check your current active version of `yarn`, run `yarn -v`_
-
-  * ![](https://img.shields.io/badge/dynamic/json.svg?style=flat-square&label=yarn+version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoryhouse%2Freact-slingshot%2Fmaster%2Fpackage.json&query=%24.engines.yarn&colorB=orange)
 
 ---
 
@@ -101,20 +95,20 @@ __YARN__ \
 3. **Run the setup script**
 
     - __NPM:__ `npm run setup`
-    - __YARN:__ `yarn setup`
 
 4. **Run the example app**
 
     - __NPM:__ `npm start -s`
-    - __YARN:__ `yarn start --silent`
 
-    This will run the automated build process, start up a webserver, and open the application in your default browser. When doing development with this kit, this command will continue watching all your files. Every time you hit save the code is rebuilt, linting runs, and tests run automatically. Note: The `-s` and `--silent` flags are optional. It enables silent mode which suppresses unnecessary messages during the build.
+    This will run the automated build process, start up a webserver, and open the application in your default browser. When doing development with this kit, this command will continue watching all your files. Every time you hit save the code is rebuilt, linting runs, and tests run automatically. Note: The `-s` flag is optional. It enables silent mode which suppresses unnecessary messages during the build.
 
-5. **Review the example app.**
+    _For **YARN** users, `yarn start --silent`_
+
+5. **Review the example app**
 
     This starter kit includes a working example app that calculates fuel savings. Note how all source code is placed under /src. Tests are placed alongside the file under test. The final built app is placed under /dist. These are the files you run in production.
 
-6. **Delete the example app files.**
+6. **Delete the example app files**
 
     Once you're comfortable with how the example app works, you can [delete those files and begin creating your own app](./docs/FAQ.md#i-just-want-an-empty-starter-kit).
 
@@ -162,10 +156,9 @@ __YARN__ \
 2. From within the project directory, run:
 
     - __NPM:__ `npm install`
-    - __YARN:__ `yarn`
-
 
     If you forget to do this, you'll see this: `babel-node: command not found`.
+
 3. Install the latest version of Node.
 
 4. Make sure files with names that begin with a dot (.editorconfig, .gitignore, .npmrc) are copied to the project directory root. This is easy to overlook if you copy this repository manually.
@@ -176,7 +169,7 @@ __YARN__ \
 
 7. Make sure you don't have NODE_ENV set to production on your machine. If you do then the [development dependencies won't be installed](https://github.com/coryhouse/react-slingshot/issues/400#issuecomment-290497767). Here's [how to check](http://stackoverflow.com/a/27939821/26180).
 
-8. Install watchman with `brew install watchman` if you are having the following error after an initial run of `npm start -s` or `yarn start --silent`:
+8. Install watchman with `brew install watchman` if you are having the following error after an initial run of `npm start -s`:
 
     ```bash
     2017-09-05 00:44 node[68587] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
@@ -190,7 +183,7 @@ __YARN__ \
         at FSEvent.FSWatcher._handle.onchange (fs.js:1406:11)
     ```
 
-9. __Tip:__ Things to check if you get an error on build or an error when running `npm run lint` or `yarn lint`:
+9. __Tip:__ Things to check if you get an error on build or an error when running `npm run lint`:
 
     * If ESW found an error or warning in your project (e.g. console statement or a missing semi-colon), the lint thread will exit with `Exit status 1`. To fix:
 
@@ -202,10 +195,9 @@ __YARN__ \
 
     * Make sure any global install you have of `eslint`/`esw` has a version that matches the version used in the project. This will ensure the `esw` keyword is resolved.
 
-10. If you are running into errors that resemble something like `Node Sass does not yet support your current environment on macOS XXX` after the initial run of `npm start -s` or `yarn start --silent`. You may need to rebuild `node-sass` before you can continue. To do so, run:
+10. If you are running into errors that resemble something like `Node Sass does not yet support your current environment on macOS XXX` after the initial run of `npm start -s`. You may need to rebuild `node-sass` before you can continue. To do so, run:
 
   - __NPM:__ `npm run rebuildNodeSass`
-  - __YARN:__ `yarn rebuildNodeSass`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,91 @@
 
 ---
 
-[![Build status: Linux](https://img.shields.io/travis/coryhouse/react-slingshot.svg?style=flat-square)](https://travis-ci.org/coryhouse/react-slingshot)
-[![Build status: Windows](https://img.shields.io/appveyor/ci/coryhouse/react-slingshot/master.svg?style=flat-square)](https://ci.appveyor.com/project/coryhouse/react-slingshot/branch/master)
-[![Dependency Status](https://david-dm.org/coryhouse/react-slingshot.svg?style=flat-square)](https://david-dm.org/coryhouse/react-slingshot)
-[![Coverage Status](https://img.shields.io/coveralls/coryhouse/react-slingshot/master.svg?style=flat-square)](https://coveralls.io/github/coryhouse/react-slingshot?branch=master)
 
-A comprehensive starter kit for rapid application development using React.
+[![Build status: Linux](https://img.shields.io/travis/coryhouse/react-slingshot.svg?style=flat-square&label=Linux+Build&logo=travis)](https://travis-ci.org/coryhouse/react-slingshot)
+[![Build status: Windows](https://img.shields.io/appveyor/ci/coryhouse/react-slingshot/master.svg?style=flat-square&label=Windows+Build&logo=appveyor)](https://ci.appveyor.com/project/coryhouse/react-slingshot/branch/master)
+[![Dependency Status](https://img.shields.io/david/coryhouse/react-slingshot.svg?logo=npm&style=flat-square)](https://david-dm.org/coryhouse/react-slingshot)
+[![Coverage Status](https://img.shields.io/coveralls/github/coryhouse/react-slingshot/master.svg?logo=github&style=flat-square)](https://coveralls.io/github/coryhouse/react-slingshot?branch=master)
 
-Why Slingshot?
+# React Slingshot ![](https://img.shields.io/github/issues-pr/coryhouse/react-slingshot.svg?style=flat-square)
 
-1. **One command to get started** - Type `npm start` to start development in your default browser.
-2. **Rapid feedback** - Each time you hit save, changes hot reload and linting and automated tests run.
-3. **One command line to check** - All feedback is displayed on a single command line.
-4. **No more JavaScript fatigue** - Slingshot uses [the most popular and powerful libraries](#technologies) for working with React.
-5. **Working example app** - The included example app shows how this all works together.
-6. **Automated production build** - Type `npm run build` to do all this:
+_A comprehensive starter kit for rapid application development using React._
 
-[![React Slingshot Production Build](https://img.youtube.com/vi/qlfDLsX-J0U/0.jpg)](https://www.youtube.com/watch?v=qlfDLsX-J0U)
+---
 
-# Get Started
+## Why Slingshot?
+
+* *__Skip The Fuss. Run One Command. Start Developing.__*
+
+  Regardless which NodeJS package manager you prefer, React Slingshot ships ready to go with full support for both __NPM__ and __YARN__ out of the box. Tackling a new project and wanna skip the headaches we all inevitably face when setting up a fresh development environment? If you'd prefer to jump straight into development and getting down to doing what you do best; With React Slingshot, all you need to do is run one, simple command:
+
+  - __NPM:__ `npm start`
+  - __YARN:__ `yarn start`
+
+  Then you're good to go!
+
+* *__Tool Agnostic, Rapid Development Feedback__*
+
+  React Slingshot makes creating apps quick and easy by offering a robust, pre-configured feature set that compliments any existing tools you already prefer. Reduce overall time spent in development at zero expense on your part. Build your application while simultaneously, automatic hot-module script reload, live-styling changes available in real-time across multiple devices, and automated tasks like linting and testing all run quietly behind the scenes. Each time you hit save, see your code edits instantly reflected in the browser without ever actually forcing a manual refresh. No browser refresh means your application state gets perserved during active development.
+
+* *__Only A Single Command Line Interface Necessary__*
+
+  No need to spend time setting up complex development debugging, logging, and notification configurations. The terminal that runs your React Slingshot based project is all you'll need. Trim down on desktop clutter and tooling dependencies. The same CLI running your project doubles as an output console which continously streams relevant development data while you work.
+
+* *__No More "JavaScript Fatigue"__*
+
+  Driven by an active community of contributers, React Slingshot sees regular updates which include the latest, bleeding-edge development enhancements. The project itself is [built atop the most powerful, widely understood community resources available](#technologies) for working with React.
+
+* *__Example App With Scripts Included__*
+
+  Whether you're new to ReactJS and want to start learning, or feel like you don't quite yet have a strong grasp on working with ReactJS alongside Redux, or even if you're coming back to ReactJS/Redux after having spent time working in a completely different tech stack and just need a good refresher; React Slingshot has you covered. By default, any time you make a fresh clone of the React Slingshot Github repository, it comes pre-packaged with the codebase for an example app. If and when you decide you no longer need the example app anymore, and are ready to shave off excess code bloat, run built-in scripts that leave you with just the bare essentials needed for development. The example app itself isn't another basic "Todo List", or any other demo you're used to seeing. React Slingshot purposefully takes covering ReactJS/Redux development fundamentals a step further; Showcasing current best practices in using ReactJS alongside Redux, as well as common ReactJS design patterns like "containers", "smart" and "dumb" components, "contolled" versus "un-controlled" components, etc. No 3rd party libraries that abstract out any of the heavy lifting are used. You get a clear, "vanillaJS" approach thats demonstrates the ReactJS way of doing things. It also serves as mini-presentation for some of the functionality React Slingshot offers for rapid application development. In terms of what you can expect to learn, the example app provides minimal, yet effective, illustrations of a few complex ReactJS/Redux design concepts you'd commonly work to implement in many projects. These include:
+
+    * Application state management while actively traversing app navigation.
+
+    * Front End routing techniques as a fallback for handling non-existent paths provided by input user input.
+
+    * Both asynchronous and synchronous functionality as UI/UX actions.
+
+    * **_and much more_**
+
+
+* *__Automated Production Ready Distributions__*
+
+  Ready to show off your finished app to the world? Running a single command:
+
+  - __NPM:__ `npm run build`
+  - __YARN:__ `yarn build`
+
+  _Gets you all of this:_
+
+  [![React Slingshot Production Build](https://img.youtube.com/vi/qlfDLsX-J0U/0.jpg)](https://www.youtube.com/watch?v=qlfDLsX-J0U)
+
+---
+
+
+## Requirements
+
+> _**IMPORTANT:** Only the supported version of the package manager you intend to use is required._
+
+__NodeJS__ \
+_To check your current active version of `node`, run `node -v`_
+
+  * ![](https://img.shields.io/badge/dynamic/json.svg?style=flat-square&label=node+version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoryhouse%2Freact-slingshot%2Fmaster%2Fpackage.json&query=%24.engines.node&colorB=orange)
+
+__NPM__ \
+  _To check your current active version of `npm`, run `npm -v`_
+
+  * ![](https://img.shields.io/badge/dynamic/json.svg?style=flat-square&label=npm+version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoryhouse%2Freact-slingshot%2Fmaster%2Fpackage.json&query=%24.engines.npm&colorB=orange)
+
+__YARN__ \
+  _To check your current active version of `yarn`, run `yarn -v`_
+
+  * ![](https://img.shields.io/badge/dynamic/json.svg?style=flat-square&label=yarn+version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoryhouse%2Freact-slingshot%2Fmaster%2Fpackage.json&query=%24.engines.yarn&colorB=orange)
+
+---
+
+
+## Get Started
 
 1. **Initial Machine Setup**
 
@@ -34,13 +100,15 @@ Why Slingshot?
 
 3. **Run the setup script**
 
-    `npm run setup`
+    - __NPM:__ `npm run setup`
+    - __YARN:__ `yarn setup`
 
 4. **Run the example app**
 
-    `npm start -s`
+    - __NPM:__ `npm start -s`
+    - __YARN:__ `yarn start --silent`
 
-    This will run the automated build process, start up a webserver, and open the application in your default browser. When doing development with this kit, this command will continue watching all your files. Every time you hit save the code is rebuilt, linting runs, and tests run automatically. Note: The -s flag is optional. It enables silent mode which suppresses unnecessary messages during the build.
+    This will run the automated build process, start up a webserver, and open the application in your default browser. When doing development with this kit, this command will continue watching all your files. Every time you hit save the code is rebuilt, linting runs, and tests run automatically. Note: The `-s` and `--silent` flags are optional. It enables silent mode which suppresses unnecessary messages during the build.
 
 5. **Review the example app.**
 
@@ -75,12 +143,12 @@ Why Slingshot?
         `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`.
 
     ### Windows
-    
+
     * **Install [Python 2.7](https://www.python.org/downloads/)**. Some node modules may rely on node-gyp, which requires Python on Windows.
     * **Install C++ Compiler**. Browser-sync requires a C++ compiler on Windows.
-    
+
       [Visual Studio Express](https://www.visualstudio.com/en-US/products/visual-studio-express-vs) comes bundled with a free C++ compiler.
-      
+
       If you already have Visual Studio installed:
       Open Visual Studio and go to File -> New -> Project -> Visual C++ -> Install Visual C++ Tools for Windows Desktop.
       The C++ compiler is used to compile browser-sync (and perhaps other Node modules).
@@ -90,13 +158,25 @@ Why Slingshot?
 ## Having Issues? Try these things first
 
 1. Make sure you ran all steps in [Get started](#get-started) including the [initial machine setup](#initial-machine-setup).
-2. Run `npm install` - If you forget to do this, you'll see this: `babel-node: command not found`.
+
+2. From within the project directory, run:
+
+    - __NPM:__ `npm install`
+    - __YARN:__ `yarn`
+
+
+    If you forget to do this, you'll see this: `babel-node: command not found`.
 3. Install the latest version of Node.
+
 4. Make sure files with names that begin with a dot (.editorconfig, .gitignore, .npmrc) are copied to the project directory root. This is easy to overlook if you copy this repository manually.
+
 5. Don't run the project from a symbolic link. It may cause issues with file watches.
+
 6. Delete any .eslintrc that you're storing in your user directory. Also, disable any ESLint plugin / custom rules that you've enabled within your editor. These will conflict with the ESLint rules defined in this project.
+
 7. Make sure you don't have NODE_ENV set to production on your machine. If you do then the [development dependencies won't be installed](https://github.com/coryhouse/react-slingshot/issues/400#issuecomment-290497767). Here's [how to check](http://stackoverflow.com/a/27939821/26180).
-8. Install watchman with `brew install watchman` if you are having the following error after an initial `npm start -s`:
+
+8. Install watchman with `brew install watchman` if you are having the following error after an initial run of `npm start -s` or `yarn start --silent`:
 
     ```bash
     2017-09-05 00:44 node[68587] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
@@ -110,17 +190,22 @@ Why Slingshot?
         at FSEvent.FSWatcher._handle.onchange (fs.js:1406:11)
     ```
 
-9. Tip: Things to check if you get an `npm run lint` error or build error:
+9. __Tip:__ Things to check if you get an error on build or an error when running `npm run lint` or `yarn lint`:
 
     * If ESW found an error or warning in your project (e.g. console statement or a missing semi-colon), the lint thread will exit with `Exit status 1`. To fix:
 
-      1. Change the `npm run lint` script to `"esw webpack.config.* src tools; exit 0"`
-      1. Change the `npm run lint:watch` script to `"esw webpack.config.* src tools --watch; exit 0"`
+      1. In the `package.json`, edit the `lint` script to read `"esw webpack.config.* src tools; exit 0"`
 
-      > Note: Adding `exit 0` will allow the npm scripts to ignore the status 1 and allow ESW to print all warnings and errors.
-    * Ensure the `eslint`/`esw` globally installed version matches the version used in the project. This will ensure the `esw` keyword is resolved.
+      2. Still in `package.json`, edit the `lint:watch` script to `"esw webpack.config.* src tools --watch; exit 0"`
 
-10. Rebuild node-sass with `npm rebuild node-sass` if you are having and error like `Node Sass does not yet support your current environment on macOS XXX` after an initial `npm start -s`.
+        > __Note:__ Adding `exit 0` will allow applications scripts to ignore the status 1, allowing ESW to print all warnings and errors.
+
+    * Make sure any global install you have of `eslint`/`esw` has a version that matches the version used in the project. This will ensure the `esw` keyword is resolved.
+
+10. If you are running into errors that resemble something like `Node Sass does not yet support your current environment on macOS XXX` after the initial run of `npm start -s` or `yarn start --silent`. You may need to rebuild `node-sass` before you can continue. To do so, run:
+
+  - __NPM:__ `npm run rebuildNodeSass`
+  - __YARN:__ `yarn rebuildNodeSass`
 
 ---
 
@@ -137,7 +222,7 @@ Slingshot offers a rich development experience using the following technologies:
 | [Webpack](https://webpack.js.org) | Bundles npm packages and our JS into a single file. Includes hot reloading via [react-transform-hmr](https://www.npmjs.com/package/react-transform-hmr). | [Quick Webpack How-to](https://github.com/petehunt/webpack-howto) [Pluralsight Course](https://www.pluralsight.com/courses/webpack-fundamentals)|
 | [Browsersync](https://www.browsersync.io/) | Lightweight development HTTP server that supports synchronized testing and debugging on multiple devices. | [Intro vid](https://www.youtube.com/watch?time_continue=1&v=heNWfzc7ufQ)|
 | [Jest](https://facebook.github.io/jest/) | Automated tests with built-in expect assertions and [Enzyme](https://github.com/airbnb/enzyme) for DOM testing without a browser using Node. | [Pluralsight Course](https://www.pluralsight.com/courses/testing-javascript) |
-| [TrackJS](https://trackjs.com/) | JavaScript error tracking. | [Free trial](https://my.trackjs.com/signup)|  
+| [TrackJS](https://trackjs.com/) | JavaScript error tracking. | [Free trial](https://my.trackjs.com/signup)|
 | [ESLint](http://eslint.org/)| Lint JS. Reports syntax and style issues. Using [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) for additional React specific linting rules. | |
 | [SASS](http://sass-lang.com/) | Compiled CSS styles with variables, functions, and more. | [Pluralsight Course](https://www.pluralsight.com/courses/better-css)|
 | [PostCSS](https://github.com/postcss/postcss) | Transform styles with JS plugins. Used to autoprefix CSS |

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "engines": {
     "node": ">=8",
     "npm": ">=3",
-    "yarn": ">=1.13.0"
+    "yarn": ">=1"
   },
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -117,8 +117,7 @@
   },
   "engines": {
     "node": ">=8",
-    "npm": ">=3",
-    "yarn": ">=1"
+    "npm": ">=3"
   },
   "jest": {
     "moduleNameMapper": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,26 @@
   "name": "react-slingshot",
   "version": "7.0.1",
   "description": "Starter kit for creating apps with React and Redux",
-  "engines": {
-    "node": ">=8",
-    "npm": ">=3"
+  "keywords": [
+    "react",
+    "reactjs",
+    "react-router",
+    "hot",
+    "reload",
+    "hmr",
+    "live",
+    "edit",
+    "webpack",
+    "redux",
+    "flux",
+    "boilerplate",
+    "starter"
+  ],
+  "license": "MIT",
+  "author": "Cory House",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coryhouse/react-slingshot"
   },
   "scripts": {
     "preinstall": "node tools/nodeVersionCheck.js",
@@ -27,10 +44,9 @@
     "test:cover:CI": "npm run test:CI -- --coverage && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js",
     "test:watch": "jest --watchAll",
     "open:cover": "npm run test:cover && opn ./coverage/lcov-report/index.html",
-    "analyze-bundle": "babel-node ./tools/analyzeBundle.js"
+    "analyze-bundle": "babel-node ./tools/analyzeBundle.js",
+    "rebuildNodeSass": "npm rebuild node-sass"
   },
-  "author": "Cory House",
-  "license": "MIT",
   "dependencies": {
     "connected-react-router": "4.4.1",
     "object-assign": "4.1.1",
@@ -99,24 +115,10 @@
     "webpack-dev-middleware": "3.2.0",
     "webpack-hot-middleware": "2.22.3"
   },
-  "keywords": [
-    "react",
-    "reactjs",
-    "react-router",
-    "hot",
-    "reload",
-    "hmr",
-    "live",
-    "edit",
-    "webpack",
-    "redux",
-    "flux",
-    "boilerplate",
-    "starter"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/coryhouse/react-slingshot"
+  "engines": {
+    "node": ">=8",
+    "npm": ">=3",
+    "yarn": ">=1.13.0"
   },
   "jest": {
     "moduleNameMapper": {


### PR DESCRIPTION
Include yarn equivalent for existing npm configs and corresponding docs

## Checklist

- [ ] Latest code from master has been merged into the pull request branch
- [ ] Honors [the seven code virtues](https://pragprog.com/magazines/2011-08/how-virtuous-is-your-code)
  - [ ] Working, as opposed to incomplete
  - [ ] Unique, as opposed to duplicated
  - [ ] Simple, as opposed to complicated
  - [ ] Clear, as opposed to puzzling
  - [ ] Easy, as opposed to difficult
  - [ ] Developed, as opposed to primitive
  - [ ] Brief, as opposed to chatty
- [ ] Code is camelCased
- [ ] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [ ] Automated tests exist and pass
- [ ] Build is successful (`npm run build`)
- [ ] Works in IE 11, Chrome, Firefox, and Edge

## Thanks!

:heart:
