### PR TITLE
ISSUE-625 Support server side routes with dots in them

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@
 * Matt Wigdahl ([mlwigdahl](https://github.com/mlwigdahl))
 * Nick Taylor ([nickytonline](https://github.com/nickytonline))
 * ReadmeCritic ([readmecritic](https://github.com/readmecritic))
+* Samuel Neff ([samuelneff](https://github.com/samuelneff))

--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -23,7 +23,12 @@ browserSync({
     baseDir: 'src',
 
     middleware: [
-      historyApiFallback(),
+      historyApiFallback(
+        {
+          disableDotRule: true,
+          htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+        }
+      ),
 
       webpackDevMiddleware(bundler, {
         // Dev middleware can't access config, so we provide publicPath


### PR DESCRIPTION
Fixes issue with 404 from server on URL such as this:

`http://localhost:3000/fuel-savings/test.two`

See:

`https://github.com/coryhouse/react-slingshot/issues/625`

## Checklist

- [X] Latest code from master has been merged into the pull request branch
- [X] Honors [the seven code virtues](https://pragprog.com/magazines/2011-08/how-virtuous-is-your-code)
  - [X] Working, as opposed to incomplete
  - [X] Unique, as opposed to duplicated
  - [X] Simple, as opposed to complicated
  - [X] Clear, as opposed to puzzling
  - [X] Easy, as opposed to difficult
  - [X] Developed, as opposed to primitive
  - [X] Brief, as opposed to chatty
- [X] Code is camelCased
- [X] No commented out code (if required, place // TODO above with explanation)
- [X] No linting issues
- [X] Automated tests exist and pass
- [X] Build is successful (`npm run build`)
- [X] Works in IE 11, Chrome, Firefox, and Edge

## Thanks!

:heart:
