### PR TITLE
Feature/add redux toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@hot-loader/react-dom": "16.10.2",
+    "@reduxjs/toolkit": "1.0.4",
     "connected-react-router": "6.5.2",
     "object-assign": "4.1.1",
     "react": "16.11.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "react-dom": "16.11.0",
     "react-redux": "7.1.1",
     "react-router-dom": "5.1.2",
-    "redux": "4.0.4",
-    "redux-thunk": "2.3.0"
+    "redux": "4.0.4"
   },
   "devDependencies": {
     "@babel/cli": "7.6.4",
@@ -92,7 +91,6 @@
     "raf": "3.4.1",
     "react-hot-loader": "4.12.15",
     "react-test-renderer": "16.11.0",
-    "redux-immutable-state-invariant": "2.1.0",
     "redux-mock-store": "1.5.3",
     "replace": "1.1.1",
     "rimraf": "3.0.0",

--- a/src/components/containers/FuelSavingsPage.js
+++ b/src/components/containers/FuelSavingsPage.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
-import * as actions from '../../actions/fuelSavingsActions';
+import {calculateFuelSavings, saveFuelSavings} from '../../actions/fuelSavingsActions';
 import FuelSavingsForm from '../FuelSavingsForm';
 
 export class FuelSavingsPage extends React.Component {
   saveFuelSavings = () => {
-    this.props.actions.saveFuelSavings(this.props.fuelSavings);
+    this.props.saveFuelSavings(this.props.fuelSavings);
   }
 
   calculateFuelSavings = e => {
-    this.props.actions.calculateFuelSavings(this.props.fuelSavings, e.target.name, e.target.value);
+    this.props.calculateFuelSavings(this.props.fuelSavings, e.target.name, e.target.value);
   }
 
   render() {
@@ -26,7 +25,8 @@ export class FuelSavingsPage extends React.Component {
 }
 
 FuelSavingsPage.propTypes = {
-  actions: PropTypes.object.isRequired,
+  saveFuelSavings: PropTypes.func.isRequired,
+  calculateFuelSavings: PropTypes.func.isRequired,
   fuelSavings: PropTypes.object.isRequired
 };
 
@@ -36,13 +36,12 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    actions: bindActionCreators(actions, dispatch)
-  };
+const mapDispatchToProps = {
+  calculateFuelSavings,
+  saveFuelSavings,
 }
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(FuelSavingsPage);

--- a/src/features/fuelSavings/fuelSavingsSlice.js
+++ b/src/features/fuelSavings/fuelSavingsSlice.js
@@ -1,0 +1,46 @@
+import {createSlice} from "@reduxjs/toolkit";
+import {necessaryDataIsProvidedToCalculateSavings, calculateSavings} from '../../utils/fuelSavings';
+
+const initialState = {
+    newMpg: '',
+    tradeMpg: '',
+    newPpg: '',
+    tradePpg: '',
+    milesDriven: '',
+    milesDrivenTimeframe: 'week',
+    displayResults: false,
+    dateModified: null,
+    necessaryDataIsProvidedToCalculateSavings: false,
+    savings: {
+        monthly: 0,
+        annual: 0,
+        threeYear: 0
+    }
+}
+
+const fuelSavingsSlice = createSlice({
+    name: "fuelSavings",
+    initialState,
+    reducers: {
+        saveFuelSavings(state, action) {
+            // For this example, just simulating a save by changing date modified.
+            // In a real app using Redux, you might use redux-thunk and handle the async call in fuelSavingsActions.js
+            state.dateModified = action.payload.dateModified;
+        },
+        calculateFuelSavings(state, action) {
+            const {fieldName, value, dateModified} = action.payload;
+
+            state[fieldName] = value;
+            state.necessaryDataIsProvidedToCalculateSavings = necessaryDataIsProvidedToCalculateSavings(state);
+            state.dateModified = dateModified;
+
+            if(state.necessaryDataIsProvidedToCalculateSavings) {
+                state.savings = calculateSavings(state);
+            }
+        }
+    }
+})
+
+export const {saveFuelSavings, calculateFuelSavings} = fuelSavingsSlice.actions;
+
+export default fuelSavingsSlice.reducer;

--- a/src/features/fuelSavings/fuelSavingsSlice.spec.js
+++ b/src/features/fuelSavings/fuelSavingsSlice.spec.js
@@ -1,0 +1,67 @@
+import reducer, {saveFuelSavings, calculateFuelSavings} from './fuelSavingsSlice';
+import {getFormattedDateTime} from '../../utils/dates';
+
+describe('Reducers::FuelSavings', () => {
+    const getInitialState = () => {
+      return {
+        newMpg: '',
+        tradeMpg: '',
+        newPpg: '',
+        tradePpg: '',
+        milesDriven: '',
+        milesDrivenTimeframe: 'week',
+        displayResults: false,
+        dateModified: null,
+        necessaryDataIsProvidedToCalculateSavings: false,
+        savings: {
+          monthly: 0,
+          annual: 0,
+          threeYear: 0
+        }
+      };
+    };
+
+    const getAppState = () => {
+        return {
+          newMpg: 20,
+          tradeMpg: 10,
+          newPpg: 1.50,
+          tradePpg: 1.50,
+          milesDriven: 100,
+          milesDrivenTimeframe: 'week',
+          displayResults: false,
+          dateModified: null,
+          necessaryDataIsProvidedToCalculateSavings: false,
+          savings: {
+            monthly: 0,
+            annual: 0,
+            threeYear: 0
+          }
+        };
+      };
+      const dateModified = getFormattedDateTime();
+
+      it('should set initial state by default', () => {
+        const action = { type: 'unknown' };
+        const expected = getInitialState();
+    
+        expect(reducer(undefined, action)).toEqual(expected);
+      });
+
+      it('should handle saveFuelSavings', () => {
+        const action = saveFuelSavings({dateModified, settings: getAppState() })
+        const expected = Object.assign(getAppState(), { dateModified });
+    
+        expect(reducer(getAppState(), action)).toEqual(expected);
+      });
+
+      it('should handle calculateFuelSavings', () => {
+        const action = calculateFuelSavings({dateModified, settings: getAppState(), fieldName: 'newMpg', value: 30 });
+    
+        const expectedMpg = 30;
+        const expectedSavings = { monthly: '$43.33', annual: '$519.96', threeYear: '$1,559.88' };
+    
+        expect(reducer(getAppState(), action).newMpg).toEqual(expectedMpg);
+        expect(reducer(getAppState(), action).savings).toEqual(expectedSavings);
+      });
+})

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,9 +2,9 @@ import { combineReducers } from 'redux';
 import fuelSavings from './fuelSavingsReducer';
 import { connectRouter } from 'connected-react-router'
 
-const rootReducer = history => combineReducers({
+const createRootReducer = history => combineReducers({
   router: connectRouter(history),
   fuelSavings,
 });
 
-export default rootReducer;
+export default createRootReducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,18 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@reduxjs/toolkit@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.0.4.tgz#cec88446a22a98b48808af7ab19a58aa93e6f5f9"
+  integrity sha512-nyCZ9/CpnMXFZ//0wm1mNPSEl0J0bCghY2qeHM8zuubaBBMBr6KsIaLLms1jThbOJ1O+Ej0Tl11z5naE9czfzA==
+  dependencies:
+    immer "^4.0.1"
+    redux "^4.0.0"
+    redux-devtools-extension "^2.13.8"
+    redux-immutable-state-invariant "^2.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -4639,6 +4651,11 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+immer@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-4.0.2.tgz#9ff0fcdf88e06f92618a5978ceecb5884e633559"
+  integrity sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w==
+
 immutable@^3, immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
@@ -8069,7 +8086,12 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-redux-immutable-state-invariant@2.1.0:
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
+redux-immutable-state-invariant@2.1.0, redux-immutable-state-invariant@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz#308fd3cc7415a0e7f11f51ec997b6379c7055ce1"
   integrity sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==
@@ -8084,12 +8106,12 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-thunk@2.3.0:
+redux-thunk@2.3.0, redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@4.0.4:
+redux@4.0.4, redux@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
@@ -8271,6 +8293,11 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8091,7 +8091,7 @@ redux-devtools-extension@^2.13.8:
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
   integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
-redux-immutable-state-invariant@2.1.0, redux-immutable-state-invariant@^2.1.0:
+redux-immutable-state-invariant@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz#308fd3cc7415a0e7f11f51ec997b6379c7055ce1"
   integrity sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==
@@ -8106,7 +8106,7 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-thunk@2.3.0, redux-thunk@^2.3.0:
+redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==


### PR DESCRIPTION
# Pull Request Template

The code review checklist below is used for all pull requests.

1.  Review the list before submitting your pull request.
2.  Leave the list intact for the code reviewer's use.

## Checklist

- [x] Latest code from master has been merged into the pull request branch
- [x] Code is camelCased
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Automated tests exist and pass
- [x] Build is successful (`npm run build`)
- [x] Works in IE 11, Chrome, Firefox, and Edge

## Details

This PR demonstrates how to convert the default example project to use Redux Toolkit, per #637 .  It is not necessarily meant to be merged as-is, although if you'd like to use it as a starting point, please do so.

### Changes

- Added `@reduxjs/toolkit` as a dependency, and removed the explicit dependencies on `redux-thunk` and `redux-immutable-state-invariant` (both of which are used internally by RTK)
- Converted the store setup logic to use RTK's `configureStore()`.  This considerably simplified the store setup logic, removing the need for separate "dev" and "prod" functions.
- Created a sample `fuelSavingsSlice.js` that is equivalent to the existing sample reducer + actions + constants files, including porting the existing reducer tests to cover the new slice file.
- Renamed `rootReducer` to `createRootReducer` for clarity
- Converted the main container component to use the "object shorthand" form of `mapDispatch`, [which is our recommended way to bind action creators](https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object).

