### PR TITLE
add link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Build status: Windows](https://img.shields.io/appveyor/ci/coryhouse/react-slingshot/master.svg?style=flat-square)](https://ci.appveyor.com/project/coryhouse/react-slingshot/branch/master)
 [![Dependency Status](https://david-dm.org/coryhouse/react-slingshot.svg?style=flat-square)](https://david-dm.org/coryhouse/react-slingshot)
 [![Coverage Status](https://img.shields.io/coveralls/coryhouse/react-slingshot/master.svg?style=flat-square)](https://coveralls.io/github/coryhouse/react-slingshot?branch=master)
+[![run on repl.it](http://repl.it/badge/github/coryhouse/react-slingshot)](https://repl.it/github/coryhouse/react-slingshot)
 
 A comprehensive starter kit for rapid application development using React.
 


### PR DESCRIPTION
# Pull Request Template

i think it would be pretty cool to let people see how this react slingshot boilerplate works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-react-slingshot):

![image](https://i.imgur.com/GlKx5OU.png)

i suppose if this is what we want, then we could possibly want the url to be owned by a more agnostic entity

## Checklist

- [x] Latest code from master has been merged into the pull request branch
- [x] Code is camelCased
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Automated tests exist and pass
- [x] Build is successful (`npm run build`)
- [x] Works in IE 11, Chrome, Firefox, and Edge